### PR TITLE
fix syntax of adding password to string for postgres connection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -327,7 +327,7 @@ async fn main() -> Result<(), tokio_postgres::Error> {
 
     let mut connect_string = format!("host={} user={} dbname={}", &args[1], &args[2], &args[3]);
     if args.len() > 4 {
-        connect_string.push(' ');
+        connect_string.push_str(" password=");
         connect_string.push_str(&args[4])
     }
 


### PR DESCRIPTION
The string for the postgres connection needed a " password=" before the password was tacked onto the end. This works for me when i have connected and run the script against the ostack instance with a password.  I also had a println when i ran it locally, since I like confirming what the string looked like:
`println!("connect string: {}", connect_string); `