### PR TITLE
Remove dependency on `test_case`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,6 @@ dependencies = [
  "quick-xml",
  "regex",
  "serde",
- "test-case",
  "thiserror",
  "tokio",
  "tokio-postgres",
@@ -1514,7 +1513,6 @@ dependencies = [
  "rove",
  "rove_connector",
  "serde",
- "test-case",
  "tokio",
  "tokio-postgres",
 ]
@@ -2770,39 +2768,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "test-case"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
-dependencies = [
- "test-case-macros",
-]
-
-[[package]]
-name = "test-case-core"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
-dependencies = [
- "cfg-if",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "test-case-macros"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
- "test-case-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ rand_distr = "0.4.3"
 regex = "1.11.1"
 rove = { git = "https://github.com/metno/rove.git" }
 serde = { version = "1.0.215", features = ["derive"] }
-test-case = "3.3.1"
 thiserror = "1.0.69"
 tokio = { version = "1.41.1", features = ["rt-multi-thread", "macros"] }
 tokio-postgres = { version = "0.7.12", features = ["with-chrono-0_4"] }

--- a/ingestion/Cargo.toml
+++ b/ingestion/Cargo.toml
@@ -24,6 +24,3 @@ serde.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-postgres.workspace = true
-
-[dev-dependencies]
-test-case.workspace = true

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -18,7 +18,6 @@ bb8-postgres.workspace = true
 rove.workspace = true
 rove_connector = { path = "../rove_connector" }
 serde.workspace = true
-test-case.workspace = true
 futures.workspace = true
 csv.workspace = true
 reqwest = {version = "0.12.9", features = ["json"]}


### PR DESCRIPTION
This macro was proving annoying by obscuring compiler errors, rustfmt, and rust_analyzer. With this we should replicate all it's behaviour except being able to see multiple case failures at once, and we get to remove a dependency as a bonus