### PR TITLE
Reported name of missing environment variable

### DIFF
--- a/ingestion/src/lib.rs
+++ b/ingestion/src/lib.rs
@@ -56,7 +56,7 @@ impl PartialEq for Error {
             (Pool(a), Pool(b)) => a.to_string() == b.to_string(),
             (Parse(a), Parse(b)) => a == b,
             (Lock(a), Lock(b)) => a == b,
-            (Env(a), Env(b)) => a.to_string() == b.to_string(),
+            (Env(a), Env(b)) => a == b,
             _ => false,
         }
     }

--- a/ingestion/src/lib.rs
+++ b/ingestion/src/lib.rs
@@ -39,7 +39,12 @@ pub enum Error {
     #[error("RwLock was poisoned: {0}")]
     Lock(String),
     #[error("Could not read environment variable: {0}")]
-    Env(#[from] std::env::VarError),
+    Env(String),
+}
+
+/// Gets an environment variable, providing more details than calling std::env::var() directly.
+pub fn getenv(key: &str) -> Result<String, Error> {
+    std::env::var(key).map_err(|_| Error::Env(format!("Environment variable not found: {}", key)))
 }
 
 impl PartialEq for Error {

--- a/ingestion/src/lib.rs
+++ b/ingestion/src/lib.rs
@@ -44,7 +44,7 @@ pub enum Error {
 
 /// Gets an environment variable, providing more details than calling std::env::var() directly.
 pub fn getenv(key: &str) -> Result<String, Error> {
-    std::env::var(key).map_err(|_| Error::Env(format!("Environment variable not found: {}", key)))
+    std::env::var(key).map_err(|e| Error::Env(format!("{e}: {key}")))
 }
 
 impl PartialEq for Error {

--- a/ingestion/src/main.rs
+++ b/ingestion/src/main.rs
@@ -4,7 +4,7 @@ use rove_connector::Connector;
 use std::sync::{Arc, RwLock};
 use tokio_postgres::NoTls;
 
-use lard_ingestion::permissions;
+use lard_ingestion::{getenv, permissions};
 
 const PARAMCONV: &str = "resources/paramconversions.csv";
 
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     // Set up postgres connection pool
     let manager =
-        PostgresConnectionManager::new_from_stringlike(std::env::var("LARD_CONN_STRING")?, NoTls)?;
+        PostgresConnectionManager::new_from_stringlike(getenv("LARD_CONN_STRING")?, NoTls)?;
     let db_pool = bb8::Pool::builder().build(manager).await?;
 
     // QC system

--- a/ingestion/src/permissions.rs
+++ b/ingestion/src/permissions.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::{getenv, Error};
 use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
@@ -41,8 +41,7 @@ pub type StationPermitTable = HashMap<StationId, PermitId>;
 /// Get a fresh cache of permits from stinfosys
 pub async fn fetch_permits() -> Result<(ParamPermitTable, StationPermitTable), Error> {
     // get stinfo conn
-    let (client, conn) =
-        tokio_postgres::connect(&std::env::var("STINFO_CONN_STRING")?, NoTls).await?;
+    let (client, conn) = tokio_postgres::connect(&getenv("STINFO_CONN_STRING")?, NoTls).await?;
 
     // conn object independently performs communication with database, so needs it's own task.
     // it will return when the client is dropped


### PR DESCRIPTION
The getenv function ican be used as a wrapper around std::env::var() to quickly see the name of any missing environment variable.

(NOTE: solution found by Manuel Carrer!)