### PR TITLE
Update db schema and fix migrations import

### DIFF
--- a/db/001-public.sql
+++ b/db/001-public.sql
@@ -49,7 +49,6 @@ CREATE TABLE IF NOT EXISTS public.data (
     CONSTRAINT fk_data_timeseries FOREIGN KEY (timeseries) REFERENCES public.timeseries
 ) PARTITION BY RANGE (obstime);
 CREATE INDEX IF NOT EXISTS data_timestamp_index ON public.data (obstime);
-CREATE INDEX IF NOT EXISTS data_timeseries_index ON public.data USING HASH (timeseries);
 
 -- TODO: this should be renamed to 'public.text' or 'public.string'
 CREATE TABLE IF NOT EXISTS public.nonscalar_data (
@@ -61,4 +60,3 @@ CREATE TABLE IF NOT EXISTS public.nonscalar_data (
     CONSTRAINT fk_nonscalar_data_timeseries FOREIGN KEY (timeseries) REFERENCES public.timeseries
 ) PARTITION BY RANGE (obstime);
 CREATE INDEX IF NOT EXISTS nonscalar_data_timestamp_index ON public.nonscalar_data (obstime);
-CREATE INDEX IF NOT EXISTS nonscalar_data_timeseries_index ON public.nonscalar_data USING HASH (timeseries);

--- a/db/001-public.sql
+++ b/db/001-public.sql
@@ -36,8 +36,8 @@ CREATE TABLE IF NOT EXISTS public.timeseries (
 );
 
 CREATE TABLE IF NOT EXISTS public.data (
-    timeseries INT8 NOT NULL,
-    obstime TIMESTAMPTZ NOT NULL,
+    timeseries INT8,
+    obstime TIMESTAMPTZ,
     obsvalue FLOAT8,
     -- This value should not be treated as an absolute assertion of the data's quality but rather
     -- our current knowlege of it. `true` here indicates that the datum has not failed any QC
@@ -45,18 +45,18 @@ CREATE TABLE IF NOT EXISTS public.data (
     -- for what QC has been performed on the data should refer to the information in the
     -- `flags.confident_provenance` table.
     qc_usable BOOLEAN NOT NULL DEFAULT TRUE,
-    CONSTRAINT unique_data_timeseries_obstime UNIQUE (timeseries, obstime),
-    CONSTRAINT fk_data_timeseries FOREIGN KEY (timeseries) REFERENCES public.timeseries
+    CONSTRAINT fk_data_timeseries FOREIGN KEY (timeseries) REFERENCES public.timeseries,
+    PRIMARY KEY (timeseries, obstime)
 ) PARTITION BY RANGE (obstime);
 CREATE INDEX IF NOT EXISTS data_timestamp_index ON public.data (obstime);
 
 -- TODO: this should be renamed to 'public.text' or 'public.string'
 CREATE TABLE IF NOT EXISTS public.nonscalar_data (
-    timeseries INT8 NOT NULL,
-    obstime TIMESTAMPTZ NOT NULL,
+    timeseries INT8,
+    obstime TIMESTAMPTZ,
     obsvalue TEXT,
     qc_usable BOOLEAN,
-    CONSTRAINT unique_nonscalar_data_timeseries_obstime UNIQUE (timeseries, obstime),
-    CONSTRAINT fk_nonscalar_data_timeseries FOREIGN KEY (timeseries) REFERENCES public.timeseries
+    CONSTRAINT fk_nonscalar_data_timeseries FOREIGN KEY (timeseries) REFERENCES public.timeseries,
+    PRIMARY KEY (timeseries, obstime)
 ) PARTITION BY RANGE (obstime);
 CREATE INDEX IF NOT EXISTS nonscalar_data_timestamp_index ON public.nonscalar_data (obstime);

--- a/db/002-labels.sql
+++ b/db/002-labels.sql
@@ -34,19 +34,12 @@ CREATE TABLE IF NOT EXISTS labels.kdvh (
 );
 CREATE INDEX IF NOT EXISTS kdvh_label_index ON labels.kdvh (tbl_name, station_id, elem_code);
 
--- This table holds extra metadata for a timeseries that was imported from kvalobs
--- TODO: import_* can be dangerous (?), kvalobs only keeps the last three months of data
--- I guess we are only dumping and importing histkvalobs for now, and only dump
--- from kvalobs when we are really close to the beta release
 CREATE TABLE IF NOT EXISTS labels.kvalobs (
     timeseries INT8 PRIMARY KEY REFERENCES public.timeseries,
     station_id INT4,
     param_id INT4,
     type_id INT4,
     lvl INT4,
-    sensor INT4,
-    -- Time range of the dumped data
-    import_from DATE,
-    import_to DATE
+    sensor INT4
 );
 CREATE INDEX IF NOT EXISTS kvalobs_label_index ON labels.kvalobs (station_id, param_id, import_from);

--- a/db/002-labels.sql
+++ b/db/002-labels.sql
@@ -42,4 +42,4 @@ CREATE TABLE IF NOT EXISTS labels.kvalobs (
     lvl INT4,
     sensor INT4
 );
-CREATE INDEX IF NOT EXISTS kvalobs_label_index ON labels.kvalobs (station_id, param_id, import_from);
+CREATE INDEX IF NOT EXISTS kvalobs_label_index ON labels.kvalobs (station_id, param_id);

--- a/db/003-flags.sql
+++ b/db/003-flags.sql
@@ -13,5 +13,4 @@ CREATE TABLE IF NOT EXISTS flags.confident_provenance (
     CONSTRAINT fk_confident_provenance_timeseries FOREIGN KEY (timeseries) REFERENCES public.timeseries
 ) PARTITION BY RANGE (obstime);
 CREATE INDEX IF NOT EXISTS confident_provenance_timestamp_index ON flags.confident_provenance (obstime);
-CREATE INDEX IF NOT EXISTS confident_provenance_timeseries_index ON flags.confident_provenance USING HASH (timeseries);
 

--- a/db/003-flags.sql
+++ b/db/003-flags.sql
@@ -2,15 +2,15 @@ CREATE SCHEMA IF NOT EXISTS flags;
 
 -- TODO: should this also have a column for qc_time or some such?
 CREATE TABLE IF NOT EXISTS flags.confident_provenance (
-    timeseries INT8 NOT NULL,
-    obstime TIMESTAMPTZ NOT NULL,
-    pipeline TEXT NOT NULL,
+    timeseries INT8,
+    obstime TIMESTAMPTZ,
+    pipeline TEXT,
     -- TODO: should this be an enum?
     flag INT4 NOT NULL,
     -- TODO: better name? since this might be applied to flags that aren't fail but also aren't pass?
     fail_condition TEXT NULL,
-    CONSTRAINT unique_confident_provenance_timeseries_obstime_pipeline UNIQUE (timeseries, obstime, pipeline),
-    CONSTRAINT fk_confident_provenance_timeseries FOREIGN KEY (timeseries) REFERENCES public.timeseries
+    CONSTRAINT fk_confident_provenance_timeseries FOREIGN KEY (timeseries) REFERENCES public.timeseries,
+    PRIMARY KEY (timeseries, obstime, pipeline)
 ) PARTITION BY RANGE (obstime);
 CREATE INDEX IF NOT EXISTS confident_provenance_timestamp_index ON flags.confident_provenance (obstime);
 

--- a/db/004-legacy.sql
+++ b/db/004-legacy.sql
@@ -15,4 +15,3 @@ CREATE TABLE IF NOT EXISTS legacy.data (
     CONSTRAINT unique_data_timeseries_obstime UNIQUE (timeseries, obstime)
 ) PARTITION BY RANGE (obstime);
 CREATE INDEX IF NOT EXISTS data_timestamp_index ON legacy.data (obstime);
-CREATE INDEX IF NOT EXISTS data_timeseries_index ON legacy.data USING HASH (timeseries);

--- a/db/004-legacy.sql
+++ b/db/004-legacy.sql
@@ -3,8 +3,8 @@ CREATE SCHEMA IF NOT EXISTS legacy;
 -- Table containing values (possibly corrected) and quality information
 -- for observations coming through kvalobs (either from old databases or from the Kafka queue)
 CREATE TABLE IF NOT EXISTS legacy.data (
-    timeseries INT8 NOT NULL REFERENCES public.timeseries,
-    obstime TIMESTAMPTZ NOT NULL,
+    timeseries INT8 REFERENCES public.timeseries,
+    obstime TIMESTAMPTZ,
     original FLOAT8 NULL,
     corrected FLOAT8 NULL,
     -- quality code of the original observation (derived from useinfo)
@@ -12,6 +12,6 @@ CREATE TABLE IF NOT EXISTS legacy.data (
     controlinfo TEXT NULL,
     useinfo TEXT NULL,
     cfailed TEXT NULL,
-    CONSTRAINT unique_data_timeseries_obstime UNIQUE (timeseries, obstime)
+   PRIMARY KEY (timeseries, obstime)
 ) PARTITION BY RANGE (obstime);
 CREATE INDEX IF NOT EXISTS data_timestamp_index ON legacy.data (obstime);

--- a/ingestion/src/kvkafka.rs
+++ b/ingestion/src/kvkafka.rs
@@ -397,7 +397,7 @@ async fn insert_kvdata(conn: &mut PooledPgConn<'_>, data: Vec<Datum>) -> Result<
         INSERT INTO legacy.data
             (timeseries, obstime, original, corrected, quality_code, controlinfo, useinfo, cfailed)
         VALUES($1, $2, $3, $4, $5, $6, $7, $8)
-        ON CONFLICT ON CONSTRAINT unique_data_timeseries_obstime
+        ON CONFLICT ON CONSTRAINT data_pkey
             DO UPDATE SET
                 original = EXCLUDED.original,
                 corrected = EXCLUDED.corrected,

--- a/ingestion/src/lib.rs
+++ b/ingestion/src/lib.rs
@@ -204,7 +204,7 @@ pub async fn insert_data(
         .prepare(
             "INSERT INTO public.data (timeseries, obstime, obsvalue, qc_usable) \
                 VALUES ($1, $2, $3, $4) \
-                ON CONFLICT ON CONSTRAINT unique_data_timeseries_obstime \
+                ON CONFLICT ON CONSTRAINT data_pkey \
                     DO UPDATE SET obsvalue = EXCLUDED.obsvalue, \
                     qc_usable = public.data.qc_usable AND EXCLUDED.qc_usable",
         )
@@ -214,7 +214,7 @@ pub async fn insert_data(
         .prepare(
             "INSERT INTO public.nonscalar_data (timeseries, obstime, obsvalue, qc_usable) \
                 VALUES ($1, $2, $3, $4) \
-                ON CONFLICT ON CONSTRAINT unique_nonscalar_data_timeseries_obstime \
+                ON CONFLICT ON CONSTRAINT nonscalar_data_pkey \
                     DO UPDATE SET obsvalue = EXCLUDED.obsvalue, \
                     qc_usable = public.nonscalar_data.qc_usable AND EXCLUDED.qc_usable",
         )
@@ -223,7 +223,7 @@ pub async fn insert_data(
         .prepare(
             "INSERT INTO flags.confident_provenance (timeseries, obstime, pipeline, flag, fail_condition) \
                 VALUES ($1, $2, $3, $4, $5) \
-                ON CONFLICT ON CONSTRAINT unique_confident_provenance_timeseries_obstime_pipeline \
+                ON CONFLICT ON CONSTRAINT confident_provenance_pkey \
                     DO UPDATE SET flag = EXCLUDED.flag, fail_condition = EXCLUDED.fail_condition",
         )
         .await?;

--- a/migrations/kdvh/import/cache.go
+++ b/migrations/kdvh/import/cache.go
@@ -90,12 +90,11 @@ func GetTsInfoAndDbPool(table, element string, station int32, cache *Cache, pool
 		TypeID:    param.TypeID,
 		ParamID:   param.ParamID,
 		Sensor:    &param.Sensor,
-		Level:     param.Hlevel,
+		LegacyLvl: param.Hlevel,
+		Level:     cache.Levels.GetLevel(param.ParamID, param.Hlevel),
 	}
 
-	level := cache.Levels.GetLevel(param.ParamID, *param.Hlevel)
-
-	tsid, err := label.CreateKDVHTimeseries(element, table, &param.Fromtime, permit, level, innerPool)
+	tsid, err := label.CreateKDVHTimeseries(element, table, &param.Fromtime, permit, innerPool)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/migrations/kdvh/import/cache.go
+++ b/migrations/kdvh/import/cache.go
@@ -17,6 +17,7 @@ type Cache struct {
 	Offsets  OffsetMap
 	Elements stinfosys.ElemMap
 	Permits  stinfosys.PermitMaps
+	Levels   stinfosys.ParamLevelMap
 }
 
 // Used for lookup of fromtime and totime from KDVH
@@ -37,6 +38,7 @@ func CacheMetadata(tables, stations, elements []string, database []*Table) *Cach
 	return &Cache{
 		Elements: stinfosys.CacheElemMap(stconn),
 		Permits:  stinfosys.NewPermitTables(stconn),
+		Levels:   stinfosys.CacheParamLevels(stconn),
 		Offsets:  cacheParamOffsets(),
 	}
 }
@@ -91,7 +93,9 @@ func GetTsInfoAndDbPool(table, element string, station int32, cache *Cache, pool
 		Level:     param.Hlevel,
 	}
 
-	tsid, err := label.CreateKDVHTimeseries(element, table, &param.Fromtime, permit, innerPool)
+	level := cache.Levels.GetLevel(param.ParamID, *param.Hlevel)
+
+	tsid, err := label.CreateKDVHTimeseries(element, table, &param.Fromtime, permit, level, innerPool)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/migrations/kdvh/import/cache.go
+++ b/migrations/kdvh/import/cache.go
@@ -85,13 +85,18 @@ func GetTsInfoAndDbPool(table, element string, station int32, cache *Cache, pool
 	// No need to check for `!ok`, will default to 0 offset
 	offset := cache.Offsets[key.Inner]
 
+	level, err := cache.Levels.GetLevel(param.ParamID, param.Hlevel)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	label := lard.Label{
 		StationID: station,
 		TypeID:    param.TypeID,
 		ParamID:   param.ParamID,
 		Sensor:    &param.Sensor,
 		LegacyLvl: param.Hlevel,
-		Level:     cache.Levels.GetLevel(param.ParamID, param.Hlevel),
+		Level:     level,
 	}
 
 	tsid, err := label.CreateKDVHTimeseries(element, table, &param.Fromtime, permit, innerPool)

--- a/migrations/kdvh/import/main.go
+++ b/migrations/kdvh/import/main.go
@@ -33,7 +33,7 @@ The following environement variables need to set:
 
 func (config *Config) Execute() {
 	if os.Getenv("GOMEMLIMIT") == "" {
-		utils.PrintGoMemLimitMessage("kvalobs")
+		utils.PrintGoMemLimitMessage("kdvh")
 		os.Exit(1)
 	}
 

--- a/migrations/kdvh/import/main.go
+++ b/migrations/kdvh/import/main.go
@@ -32,7 +32,10 @@ The following environement variables need to set:
 }
 
 func (config *Config) Execute() {
-	utils.GoMemLimitMessage("kdvh")
+	if os.Getenv("GOMEMLIMIT") == "" {
+		utils.PrintGoMemLimitMessage("kvalobs")
+		os.Exit(1)
+	}
 
 	err := godotenv.Load()
 	if err != nil {

--- a/migrations/kvalobs/db/label.go
+++ b/migrations/kvalobs/db/label.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strings"
 
-	"migrate/lard"
 	"migrate/utils"
 
 	"github.com/gocarina/gocsv"
@@ -47,12 +46,6 @@ func (l *Label) sensorLevelString() (sensor string, level string) {
 func (l *Label) ToFilename() string {
 	sensor, level := l.sensorLevelString()
 	return fmt.Sprintf("%v_%v_%v_%v_%v.csv", l.StationID, l.ParamID, l.TypeID, sensor, level)
-}
-
-// Cast kvalobs Label to lard.Label
-func (l *Label) ToLard() *lard.Label {
-	label := lard.Label(*l)
-	return &label
 }
 
 func parseFilenameFields(s *string) (*int32, error) {

--- a/migrations/kvalobs/import/cache.go
+++ b/migrations/kvalobs/import/cache.go
@@ -19,6 +19,7 @@ type KvalobsTimespanMap = map[MetaKey]utils.TimeSpan
 type Cache struct {
 	Meta    map[string]KvalobsTimespanMap
 	Permits stinfosys.PermitMaps
+	Levels  stinfosys.ParamLevelMap
 }
 
 func NewCache() *Cache {
@@ -26,9 +27,10 @@ func NewCache() *Cache {
 	defer conn.Close(ctx)
 
 	permits := stinfosys.NewPermitTables(conn)
+	levels := stinfosys.CacheParamLevels(conn)
 	meta := make(map[string]KvalobsTimespanMap)
 
-	return &Cache{Permits: permits, Meta: meta}
+	return &Cache{Permits: permits, Levels: levels, Meta: meta}
 }
 
 // Cache database metadata if not already present

--- a/migrations/kvalobs/import/import.go
+++ b/migrations/kvalobs/import/import.go
@@ -156,10 +156,11 @@ func (table *Table) getTsidAndDbPool(label *kvalobs.Label, cache *Cache, pools *
 	if err != nil {
 		return 0, nil, err
 	}
+	level := cache.Levels.GetLevel(label.ParamID, *label.Level)
 
 	// TODO: figure out where to get fromtime, kvalobs directly? Stinfosys?
 	lardLabel := label.ToLard()
-	tsid, err := lardLabel.CreateKvalobsTimeseries(tsTimespan, permit, innerPool)
+	tsid, err := lardLabel.CreateKvalobsTimeseries(tsTimespan, permit, level, innerPool)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/migrations/kvalobs/import/import.go
+++ b/migrations/kvalobs/import/import.go
@@ -156,11 +156,18 @@ func (table *Table) getTsidAndDbPool(label *kvalobs.Label, cache *Cache, pools *
 	if err != nil {
 		return 0, nil, err
 	}
-	level := cache.Levels.GetLevel(label.ParamID, *label.Level)
+
+	lardLabel := lard.Label{
+		StationID: label.StationID,
+		TypeID:    label.TypeID,
+		ParamID:   label.ParamID,
+		Sensor:    label.Sensor,
+		LegacyLvl: label.Level,
+		Level:     cache.Levels.GetLevel(label.ParamID, label.Level),
+	}
 
 	// TODO: figure out where to get fromtime, kvalobs directly? Stinfosys?
-	lardLabel := label.ToLard()
-	tsid, err := lardLabel.CreateKvalobsTimeseries(tsTimespan, permit, level, innerPool)
+	tsid, err := lardLabel.CreateKvalobsTimeseries(tsTimespan, permit, innerPool)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/migrations/kvalobs/import/import.go
+++ b/migrations/kvalobs/import/import.go
@@ -157,13 +157,18 @@ func (table *Table) getTsidAndDbPool(label *kvalobs.Label, cache *Cache, pools *
 		return 0, nil, err
 	}
 
+	level, err := cache.Levels.GetLevel(label.ParamID, label.Level)
+	if err != nil {
+		return 0, nil, err
+	}
+
 	lardLabel := lard.Label{
 		StationID: label.StationID,
 		TypeID:    label.TypeID,
 		ParamID:   label.ParamID,
 		Sensor:    label.Sensor,
 		LegacyLvl: label.Level,
-		Level:     cache.Levels.GetLevel(label.ParamID, label.Level),
+		Level:     level,
 	}
 
 	// TODO: figure out where to get fromtime, kvalobs directly? Stinfosys?

--- a/migrations/kvalobs/import/import.go
+++ b/migrations/kvalobs/import/import.go
@@ -37,12 +37,6 @@ func (table *Table) Import(cache *Cache, pools *lard.Pools, config *Config) (int
 		return 0, err
 	}
 
-	importSpan, err := utils.TimespanFromDirName(config.SpanDir)
-	if err != nil {
-		log.Error().Err(err).Msg("")
-		return 0, err
-	}
-
 	// Used to limit number of spawned threads
 	// Too many threads can lead to an OOM kill, due to slice allocations in table.Import
 	semaphore := make(chan struct{}, config.MaxWorkers)
@@ -87,7 +81,7 @@ func (table *Table) Import(cache *Cache, pools *lard.Pools, config *Config) (int
 					return
 				}
 
-				tsid, pool, err := table.getTsidAndDbPool(label, *importSpan, cache, pools)
+				tsid, pool, err := table.getTsidAndDbPool(label, cache, pools)
 				if err != nil {
 					log.Error().Err(err).Interface("label", label).Msg("")
 					return
@@ -149,7 +143,7 @@ func importLabel(file *os.File, tsid int64, label *kvalobs.Label, pool *pgxpool.
 	return parsed.Insert(pool)
 }
 
-func (table *Table) getTsidAndDbPool(label *kvalobs.Label, importSpan utils.TimeSpan, cache *Cache, pools *lard.Pools) (int64, *pgxpool.Pool, error) {
+func (table *Table) getTsidAndDbPool(label *kvalobs.Label, cache *Cache, pools *lard.Pools) (int64, *pgxpool.Pool, error) {
 	innerPool := pools.Restricted
 
 	permit := cache.GetPermit(label.StationID, label.TypeID, label.ParamID)
@@ -165,7 +159,7 @@ func (table *Table) getTsidAndDbPool(label *kvalobs.Label, importSpan utils.Time
 
 	// TODO: figure out where to get fromtime, kvalobs directly? Stinfosys?
 	lardLabel := label.ToLard()
-	tsid, err := lardLabel.CreateKvalobsTimeseries(importSpan, tsTimespan, permit, innerPool)
+	tsid, err := lardLabel.CreateKvalobsTimeseries(tsTimespan, permit, innerPool)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/migrations/kvalobs/import/main.go
+++ b/migrations/kvalobs/import/main.go
@@ -30,7 +30,10 @@ The following environement variables need to set:
 }
 
 func (config *Config) Execute() {
-	utils.GoMemLimitMessage("kvalobs")
+	if os.Getenv("GOMEMLIMIT") == "" {
+		utils.PrintGoMemLimitMessage("kvalobs")
+		os.Exit(1)
+	}
 
 	if err := config.CheckSpelling(); err != nil {
 		fmt.Println(err)

--- a/migrations/lard/index/drop.go
+++ b/migrations/lard/index/drop.go
@@ -66,6 +66,7 @@ func DropIndices(database string) {
 		}
 
 		if err := group.Wait(); err != nil {
+			fmt.Println(err)
 			continue
 		}
 

--- a/migrations/lard/timeseries.go
+++ b/migrations/lard/timeseries.go
@@ -14,7 +14,9 @@ type Label struct {
 	ParamID   int32
 	TypeID    int32
 	Sensor    *int32
-	// Level converted to cm
+	// Metereological level in cm
+	// This also maps the default level (0) in legacy systems to the actual
+	// metereological level
 	Level *int32
 	// Original Hlevel in legacy systems
 	LegacyLvl *int32

--- a/migrations/lard/timeseries.go
+++ b/migrations/lard/timeseries.go
@@ -14,11 +14,14 @@ type Label struct {
 	ParamID   int32
 	TypeID    int32
 	Sensor    *int32
-	Level     *int32
+	// Level converted to cm
+	Level *int32
+	// Original Hlevel in legacy systems
+	LegacyLvl *int32
 }
 
 // NOTE: fromtime is taken from Stinfosys elem_map_cfnames_param (which might not be the correct value)
-func (label *Label) CreateKDVHTimeseries(element, table_name string, fromtime *time.Time, permit *int32, level *int32, pool *pgxpool.Pool) (tsid int64, err error) {
+func (label *Label) CreateKDVHTimeseries(element, table_name string, fromtime *time.Time, permit *int32, pool *pgxpool.Pool) (tsid int64, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -30,7 +33,7 @@ func (label *Label) CreateKDVHTimeseries(element, table_name string, fromtime *t
               AND sensor = $4
               AND elem_code = $5
               AND tbl_name = $6`,
-		label.StationID, label.TypeID, label.Level, label.Sensor, element, table_name)
+		label.StationID, label.TypeID, label.LegacyLvl, label.Sensor, element, table_name)
 
 	err = row.Scan(&tsid)
 	if err == nil {
@@ -58,7 +61,7 @@ func (label *Label) CreateKDVHTimeseries(element, table_name string, fromtime *t
 		ctx,
 		`INSERT INTO labels.kdvh (timeseries, station_id, type_id, lvl, sensor, elem_code, tbl_name)
             VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-		tsid, label.StationID, label.TypeID, label.Level, label.Sensor, element, table_name)
+		tsid, label.StationID, label.TypeID, label.LegacyLvl, label.Sensor, element, table_name)
 	if err != nil {
 		return tsid, err
 	}
@@ -68,7 +71,7 @@ func (label *Label) CreateKDVHTimeseries(element, table_name string, fromtime *t
 		ctx,
 		`INSERT INTO labels.met (timeseries, station_id, param_id, type_id, lvl, sensor)
             VALUES ($1, $2, $3, $4, $5, $6)`,
-		tsid, label.StationID, label.ParamID, label.TypeID, level, label.Sensor)
+		tsid, label.StationID, label.ParamID, label.TypeID, label.Level, label.Sensor)
 	if err != nil {
 		return tsid, err
 	}
@@ -77,7 +80,7 @@ func (label *Label) CreateKDVHTimeseries(element, table_name string, fromtime *t
 	return tsid, err
 }
 
-func (label *Label) CreateKvalobsTimeseries(tsTimespan utils.TimeSpan, permit *int32, level *int32, pool *pgxpool.Pool) (tsid int64, err error) {
+func (label *Label) CreateKvalobsTimeseries(tsTimespan utils.TimeSpan, permit *int32, pool *pgxpool.Pool) (tsid int64, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -88,7 +91,7 @@ func (label *Label) CreateKvalobsTimeseries(tsTimespan utils.TimeSpan, permit *i
               ANd type_id = $3
               AND lvl = $4
               AND sensor = $5`,
-		label.StationID, label.ParamID, label.TypeID, label.Level, label.Sensor)
+		label.StationID, label.ParamID, label.TypeID, label.LegacyLvl, label.Sensor)
 
 	err = row.Scan(&tsid)
 	if err == nil {
@@ -121,7 +124,7 @@ func (label *Label) CreateKvalobsTimeseries(tsTimespan utils.TimeSpan, permit *i
 		ctx,
 		`INSERT INTO labels.kvalobs (timeseries, station_id, param_id, type_id, lvl, sensor)
             VALUES ($1, $2, $3, $4, $5, $6)`,
-		tsid, label.StationID, label.ParamID, label.TypeID, label.Level, label.Sensor)
+		tsid, label.StationID, label.ParamID, label.TypeID, label.LegacyLvl, label.Sensor)
 	if err != nil {
 		return tsid, err
 	}
@@ -131,7 +134,7 @@ func (label *Label) CreateKvalobsTimeseries(tsTimespan utils.TimeSpan, permit *i
 		ctx,
 		`INSERT INTO labels.met (timeseries, station_id, param_id, type_id, lvl, sensor)
             VALUES ($1, $2, $3, $4, $5, $6)`,
-		tsid, label.StationID, label.ParamID, label.TypeID, level, label.Sensor)
+		tsid, label.StationID, label.ParamID, label.TypeID, label.Level, label.Sensor)
 	if err != nil {
 		return tsid, err
 	}

--- a/migrations/lard/timeseries.go
+++ b/migrations/lard/timeseries.go
@@ -76,7 +76,7 @@ func (label *Label) CreateKDVHTimeseries(element, table_name string, fromtime *t
 	return tsid, err
 }
 
-func (label *Label) CreateKvalobsTimeseries(importSpan, tsTimespan utils.TimeSpan, permit *int32, pool *pgxpool.Pool) (tsid int64, err error) {
+func (label *Label) CreateKvalobsTimeseries(tsTimespan utils.TimeSpan, permit *int32, pool *pgxpool.Pool) (tsid int64, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -86,10 +86,8 @@ func (label *Label) CreateKvalobsTimeseries(importSpan, tsTimespan utils.TimeSpa
               AND param_id = $2
               ANd type_id = $3
               AND lvl = $4
-              AND sensor = $5
-              AND import_from = $6
-              AND import_to = $7`,
-		label.StationID, label.ParamID, label.TypeID, label.Level, label.Sensor, importSpan.From, importSpan.To)
+              AND sensor = $5`,
+		label.StationID, label.ParamID, label.TypeID, label.Level, label.Sensor)
 
 	err = row.Scan(&tsid)
 	if err == nil {
@@ -120,9 +118,9 @@ func (label *Label) CreateKvalobsTimeseries(importSpan, tsTimespan utils.TimeSpa
 
 	_, err = transaction.Exec(
 		ctx,
-		`INSERT INTO labels.kvalobs (timeseries, station_id, param_id, type_id, lvl, sensor, import_from, import_to)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-		tsid, label.StationID, label.ParamID, label.TypeID, label.Level, label.Sensor, importSpan.From, importSpan.To)
+		`INSERT INTO labels.kvalobs (timeseries, station_id, param_id, type_id, lvl, sensor)
+            VALUES ($1, $2, $3, $4, $5, $6)`,
+		tsid, label.StationID, label.ParamID, label.TypeID, label.Level, label.Sensor)
 	if err != nil {
 		return tsid, err
 	}

--- a/migrations/lard/timeseries.go
+++ b/migrations/lard/timeseries.go
@@ -18,7 +18,7 @@ type Label struct {
 }
 
 // NOTE: fromtime is taken from Stinfosys elem_map_cfnames_param (which might not be the correct value)
-func (label *Label) CreateKDVHTimeseries(element, table_name string, fromtime *time.Time, permit *int32, pool *pgxpool.Pool) (tsid int64, err error) {
+func (label *Label) CreateKDVHTimeseries(element, table_name string, fromtime *time.Time, permit *int32, level *int32, pool *pgxpool.Pool) (tsid int64, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -63,11 +63,12 @@ func (label *Label) CreateKDVHTimeseries(element, table_name string, fromtime *t
 		return tsid, err
 	}
 
+	// for the MET label we use the converted level
 	_, err = transaction.Exec(
 		ctx,
 		`INSERT INTO labels.met (timeseries, station_id, param_id, type_id, lvl, sensor)
             VALUES ($1, $2, $3, $4, $5, $6)`,
-		tsid, label.StationID, label.ParamID, label.TypeID, label.Level, label.Sensor)
+		tsid, label.StationID, label.ParamID, label.TypeID, level, label.Sensor)
 	if err != nil {
 		return tsid, err
 	}
@@ -76,7 +77,7 @@ func (label *Label) CreateKDVHTimeseries(element, table_name string, fromtime *t
 	return tsid, err
 }
 
-func (label *Label) CreateKvalobsTimeseries(tsTimespan utils.TimeSpan, permit *int32, pool *pgxpool.Pool) (tsid int64, err error) {
+func (label *Label) CreateKvalobsTimeseries(tsTimespan utils.TimeSpan, permit *int32, level *int32, pool *pgxpool.Pool) (tsid int64, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
@@ -125,11 +126,12 @@ func (label *Label) CreateKvalobsTimeseries(tsTimespan utils.TimeSpan, permit *i
 		return tsid, err
 	}
 
+	// for the MET label we use the converted level
 	_, err = transaction.Exec(
 		ctx,
 		`INSERT INTO labels.met (timeseries, station_id, param_id, type_id, lvl, sensor)
             VALUES ($1, $2, $3, $4, $5, $6)`,
-		tsid, label.StationID, label.ParamID, label.TypeID, label.Level, label.Sensor)
+		tsid, label.StationID, label.ParamID, label.TypeID, level, label.Sensor)
 	if err != nil {
 		return tsid, err
 	}

--- a/migrations/stinfosys/levels.go
+++ b/migrations/stinfosys/levels.go
@@ -23,7 +23,7 @@ func CacheParamLevels(conn *pgx.Conn) ParamLevelMap {
 
 	rows, err := conn.Query(
 		context.TODO(),
-		"SELECT standard_hlevel, hlevel_scale, paramid FROM param WHERE standard_hlevel is not null",
+		"SELECT paramid, standard_hlevel, hlevel_scale FROM param WHERE standard_hlevel is not null",
 	)
 	if err != nil {
 		fmt.Println("\n", err)

--- a/migrations/stinfosys/levels.go
+++ b/migrations/stinfosys/levels.go
@@ -52,8 +52,9 @@ func CacheParamLevels(conn *pgx.Conn) ParamLevelMap {
 }
 
 func (levels ParamLevelMap) GetLevel(paramid int32, lvl *int32) *int32 {
-	// Level is not the default one so it is already correct
-	if lvl == nil || (lvl != nil && *lvl != 0) {
+	// In practice level should always be different than NULL
+	// due to default values in legacy systems
+	if lvl == nil {
 		return lvl
 	}
 
@@ -62,7 +63,10 @@ func (levels ParamLevelMap) GetLevel(paramid int32, lvl *int32) *int32 {
 		return nil
 	}
 
-	level := paramLevel.Hlevel
+	level := *lvl
+	if level == 0 {
+		level = paramLevel.Hlevel
+	}
 
 	switch paramLevel.Scale {
 	case 0:

--- a/migrations/stinfosys/levels.go
+++ b/migrations/stinfosys/levels.go
@@ -13,8 +13,8 @@ type ParamId = int32
 type ParamLevelMap map[ParamId]ParamLevel
 
 type ParamLevel struct {
-	Hlevel       int32
-	Hlevel_scale int32
+	Hlevel int32
+	Scale  int32
 }
 
 func CacheParamLevels(conn *pgx.Conn) ParamLevelMap {
@@ -34,7 +34,7 @@ func CacheParamLevels(conn *pgx.Conn) ParamLevelMap {
 		var param ParamId
 		var level ParamLevel
 
-		if err := rows.Scan(&param, &level.Hlevel, &level.Hlevel_scale); err != nil {
+		if err := rows.Scan(&param, &level.Hlevel, &level.Scale); err != nil {
 			fmt.Println("\n", err)
 			os.Exit(1)
 		}
@@ -51,27 +51,30 @@ func CacheParamLevels(conn *pgx.Conn) ParamLevelMap {
 	return cache
 }
 
-func (levels ParamLevelMap) GetLevel(paramid, lvl int32) *int32 {
-	var level = lvl
-	// First check param permit table
-	if level_and_scale, ok := levels[paramid]; ok {
-		if lvl == 0 {
-			// override with default
-			level = level_and_scale.Hlevel
-		}
-		// convert to cm
-		if level_and_scale.Hlevel_scale == 0 {
-			// was m, convert to cm
-			level = level * 100
-			return &level
-		} else if level_and_scale.Hlevel_scale == -2 {
-			// is cm so do nothing
-			return &level
-		} else {
-			fmt.Println("found a scale that was not 0 or -2, eeek!!!")
-			return &level
-		}
+func (levels ParamLevelMap) GetLevel(paramid int32, lvl *int32) *int32 {
+	// Level is not the default one so it is already correct
+	if lvl == nil || (lvl != nil && *lvl != 0) {
+		return lvl
 	}
 
-	return nil
+	paramLevel, ok := levels[paramid]
+	if !ok {
+		return nil
+	}
+
+	level := paramLevel.Hlevel
+
+	switch paramLevel.Scale {
+	case 0:
+		// level is in m, convert to cm
+		level = level * 100
+		return &level
+	case -2:
+		// level is in cm so we don't need to convert it
+		return &level
+	default:
+		// TODO: this should return an error? And maybe add the scale in the message?
+		fmt.Println("found a scale that was not 0 or -2, eeek!!!")
+		return &level
+	}
 }

--- a/migrations/stinfosys/levels.go
+++ b/migrations/stinfosys/levels.go
@@ -51,19 +51,14 @@ func CacheParamLevels(conn *pgx.Conn) ParamLevelMap {
 	return cache
 }
 
-func (levels ParamLevelMap) GetLevel(paramid int32, lvl *int32) *int32 {
-	// In practice level should always be different than NULL
-	// due to default values in legacy systems
-	if lvl == nil {
-		return lvl
-	}
-
+func (levels ParamLevelMap) GetLevel(paramid int32, legacyLevel *int32) (*int32, error) {
 	paramLevel, ok := levels[paramid]
-	if !ok {
-		return nil
+	// return if level was not found in the map or the legacy level is NULL
+	if !ok || legacyLevel == nil {
+		return nil, nil
 	}
 
-	level := *lvl
+	level := *legacyLevel
 	if level == 0 {
 		level = paramLevel.Hlevel
 	}
@@ -72,13 +67,11 @@ func (levels ParamLevelMap) GetLevel(paramid int32, lvl *int32) *int32 {
 	case 0:
 		// level is in m, convert to cm
 		level = level * 100
-		return &level
+		return &level, nil
 	case -2:
 		// level is in cm so we don't need to convert it
-		return &level
+		return &level, nil
 	default:
-		// TODO: this should return an error? And maybe add the scale in the message?
-		fmt.Println("found a scale that was not 0 or -2, eeek!!!")
-		return &level
+		return nil, fmt.Errorf("Unknown level scale: %d", paramLevel.Scale)
 	}
 }

--- a/migrations/stinfosys/levels.go
+++ b/migrations/stinfosys/levels.go
@@ -1,0 +1,77 @@
+package stinfosys
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type ParamId = int32
+
+type ParamLevelMap map[ParamId]ParamLevel
+
+type ParamLevel struct {
+	Hlevel       int32
+	Hlevel_scale int32
+}
+
+func CacheParamLevels(conn *pgx.Conn) ParamLevelMap {
+	fmt.Printf("%50s", "Caching StinfoSys param table... ")
+	cache := make(ParamLevelMap)
+
+	rows, err := conn.Query(
+		context.TODO(),
+		"SELECT standard_hlevel, hlevel_scale, paramid FROM param WHERE standard_hlevel is not null",
+	)
+	if err != nil {
+		fmt.Println("\n", err)
+		os.Exit(1)
+	}
+
+	for rows.Next() {
+		var param ParamId
+		var level ParamLevel
+
+		if err := rows.Scan(&param, &level.Hlevel, &level.Hlevel_scale); err != nil {
+			fmt.Println("\n", err)
+			os.Exit(1)
+		}
+
+		cache[param] = level
+	}
+
+	if rows.Err() != nil {
+		fmt.Println("\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("Done!")
+	return cache
+}
+
+func (levels ParamLevelMap) GetLevel(paramid, lvl int32) *int32 {
+	var level = lvl
+	// First check param permit table
+	if level_and_scale, ok := levels[paramid]; ok {
+		if lvl == 0 {
+			// override with default
+			level = level_and_scale.Hlevel
+		}
+		// convert to cm
+		if level_and_scale.Hlevel_scale == 0 {
+			// was m, convert to cm
+			level = level * 100
+			return &level
+		} else if level_and_scale.Hlevel_scale == -2 {
+			// is cm so do nothing
+			return &level
+		} else {
+			fmt.Println("found a scale that was not 0 or -2, eeek!!!")
+			return &level
+		}
+	}
+
+	return nil
+}

--- a/migrations/stinfosys/permissions.go
+++ b/migrations/stinfosys/permissions.go
@@ -8,8 +8,6 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-const STINFO_ENV_VAR string = "STINFO_CONN_STRING"
-
 type StationId = int32
 type PermitId = int32
 

--- a/migrations/utils/utils.go
+++ b/migrations/utils/utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 func PrintGoMemLimitMessage(packageName string) {
-	fmt.Println("To avoid OOM kills, set the GOMEMLIMIT environement variable.")
+	fmt.Println("To avoid OOM kills, set the GOMEMLIMIT environment variable.")
 	fmt.Println("For example:")
 	fmt.Printf("\tGOMEMLIMIT=4GiB ./migrate %s import ...\n", packageName)
 }

--- a/migrations/utils/utils.go
+++ b/migrations/utils/utils.go
@@ -11,13 +11,10 @@ import (
 	"github.com/schollz/progressbar/v3"
 )
 
-func GoMemLimitMessage(packageName string) {
-	if os.Getenv("GOMEMLIMIT") == "" {
-		fmt.Println("To avoid OOM kills, set the GOMEMLIMIT environement variable.")
-		fmt.Println("For example:")
-		fmt.Printf("\tGOMEMLIMIT=4GiB ./migrate %s import ...\n", packageName)
-		os.Exit(1)
-	}
+func PrintGoMemLimitMessage(packageName string) {
+	fmt.Println("To avoid OOM kills, set the GOMEMLIMIT environement variable.")
+	fmt.Println("For example:")
+	fmt.Printf("\tGOMEMLIMIT=4GiB ./migrate %s import ...\n", packageName)
 }
 
 // Create a new progress bar


### PR DESCRIPTION
1. Remove the creation of duplicate timeseries for different dump files (dropping the `import_from` and `import_to` columns from `labels.kvalobs`)
1. Remove hash indexes
1. Convert level for the `labels.met` table when importing