### PR TITLE
Add IDF event endpoint

### DIFF
--- a/egress/src/error.rs
+++ b/egress/src/error.rs
@@ -2,20 +2,22 @@ use axum::http::StatusCode;
 use thiserror::Error;
 use tokio::task::JoinError;
 
-/// Utility function for mapping any error into a `500 Internal Server Error`
-/// response.
+/// Utility function for mapping any error into a `500 Internal Server Error` response.
 pub fn internal_error<E: std::error::Error>(err: E) -> (StatusCode, String) {
     (StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
 }
 
+/// Utility function for mapping any error into a `401 Unauthorized` response.
 pub fn unauthorized<E: std::error::Error>(err: E) -> (StatusCode, String) {
     (StatusCode::UNAUTHORIZED, err.to_string())
 }
 
+/// Utility function for mapping any error into a `404 Not Found Error` response.
 pub fn not_found_error<E: std::error::Error>(err: E) -> (StatusCode, String) {
     (StatusCode::NOT_FOUND, err.to_string())
 }
 
+/// Utility function for mapping any error into a `400 Bad Request Error` response.
 pub fn bad_request<E: std::error::Error>(err: E) -> (StatusCode, String) {
     (StatusCode::BAD_REQUEST, err.to_string())
 }

--- a/egress/src/error.rs
+++ b/egress/src/error.rs
@@ -12,6 +12,10 @@ pub fn unauthorized<E: std::error::Error>(err: E) -> (StatusCode, String) {
     (StatusCode::UNAUTHORIZED, err.to_string())
 }
 
+pub fn not_found_error<E: std::error::Error>(err: E) -> (StatusCode, String) {
+    (StatusCode::NOT_FOUND, err.to_string())
+}
+
 pub fn bad_request<E: std::error::Error>(err: E) -> (StatusCode, String) {
     (StatusCode::BAD_REQUEST, err.to_string())
 }

--- a/egress/src/lib.rs
+++ b/egress/src/lib.rs
@@ -19,7 +19,7 @@ use tower_http::compression::CompressionLayer;
 
 use util::DbPools;
 
-use patchwork::{get_patchwork, PatchworkDatum, PatchworkLabel, PatchworkTimeseriesTables};
+use patchwork::{get_patchwork, PatchworkDatum, PatchworkLabel, PatchworkTables};
 
 use auth::{auth_middleware, JWKScerts};
 
@@ -41,7 +41,7 @@ pub struct EgressState {
     // pub s3_client: S3Client,
     s3_bucket: S3Bucket,
     // patchwork table(s) - open and restricted
-    patchwork_tables: PatchworkTimeseriesTables,
+    patchwork_tables: PatchworkTables,
 }
 
 impl FromRef<EgressState> for DbPools {
@@ -56,8 +56,8 @@ impl FromRef<EgressState> for S3Bucket {
     }
 }
 
-impl FromRef<EgressState> for PatchworkTimeseriesTables {
-    fn from_ref(state: &EgressState) -> PatchworkTimeseriesTables {
+impl FromRef<EgressState> for PatchworkTables {
+    fn from_ref(state: &EgressState) -> PatchworkTables {
         state.patchwork_tables.clone()
     }
 }
@@ -187,7 +187,7 @@ async fn latest_handler(
 
 async fn patchwork_handler(
     State(pools): State<DbPools>,
-    State(patchwork_tables): State<PatchworkTimeseriesTables>,
+    State(patchwork_tables): State<PatchworkTables>,
     Query(params): Query<PatchworkParams>,
     Extension(roles): Extension<Option<Vec<i32>>>,
 ) -> Result<Json<Vec<PatchworkResp>>, (StatusCode, String)> {
@@ -277,7 +277,7 @@ async fn patchwork_handler(
 }
 
 pub async fn patchwork_available_handler(
-    State(patchwork_tables): State<PatchworkTimeseriesTables>,
+    State(patchwork_tables): State<PatchworkTables>,
 ) -> Result<Json<PatchworkAvailableResp>, (StatusCode, String)> {
     let mut available_list: Vec<PatchworkAvailable> = Vec::new();
     let ot = patchwork_tables
@@ -316,7 +316,7 @@ pub async fn patchwork_available_handler(
 pub async fn run(
     db_pools: DbPools,
     s3_bucket: S3Bucket,
-    patchwork_tables: PatchworkTimeseriesTables,
+    patchwork_tables: PatchworkTables,
     auth_certs: JWKScerts,
     cancel_token: CancellationToken,
 ) {

--- a/egress/src/lib.rs
+++ b/egress/src/lib.rs
@@ -20,7 +20,7 @@ use tower_http::compression::CompressionLayer;
 
 use util::DbPools;
 
-use patchwork::{get_patchwork, PatchworkData, PatchworkLabel, PatchworkTimeseriesTables};
+use patchwork::{get_patchwork, PatchworkDatum, PatchworkLabel, PatchworkTimeseriesTables};
 
 use auth::{auth_middleware, JWKScerts};
 
@@ -103,7 +103,7 @@ struct PatchworkParams {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PatchworkResp {
     pub label: PatchworkLabel,
-    pub data: Vec<PatchworkData>,
+    pub data: Vec<PatchworkDatum>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/egress/src/lib.rs
+++ b/egress/src/lib.rs
@@ -314,7 +314,9 @@ pub async fn patchwork_available_handler(
 
         for (label, fills) in rt.iter() {
             // Skip if request has wrong permits
-            if !fills.iter().any(|fill| roles.contains(&fill.permit)) {
+            // NOTE: All fills have the same permit id (since restrictions are applied to whole
+            // stations or single params)
+            if !roles.contains(&fills[0].permit) {
                 continue;
             }
 

--- a/egress/src/lib.rs
+++ b/egress/src/lib.rs
@@ -279,17 +279,9 @@ pub async fn patchwork_available_handler(
     let ot = tables.open.read().map_err(error::internal_error)?;
 
     for (label, fills) in ot.iter() {
-        // find first and last times
-        let first_time = fills.iter().map(|item| item.from).min().unwrap();
-        let last_time = if fills.iter().any(|item| item.to.is_none()) {
-            // if there is a None to time, that means the series is open ended,
-            // which is the latest possible to time. but Option's Ord impl
-            // counts None as less than Some. So we have this if check to
-            // override that behaviour
-            None
-        } else {
-            fills.iter().map(|item| item.to).max().unwrap()
-        };
+        // fills are already sorted
+        let first_time = fills[0].from;
+        let last_time = fills.iter().last().map(|fill| fill.to).unwrap();
 
         // The restrictions are all the same for a given label, so just take the first one
         let permit = fills[0].permit;
@@ -313,13 +305,9 @@ pub async fn patchwork_available_handler(
                 continue;
             }
 
-            let first_time = fills.iter().map(|fill| fill.from).min().unwrap();
-            let last_time = if fills.iter().any(|fill| fill.to.is_none()) {
-                // Same as in the comment above when iterating over open table
-                None
-            } else {
-                fills.iter().map(|fill| fill.to).max().unwrap()
-            };
+            // fills are already sorted
+            let first_time = fills[0].from;
+            let last_time = fills.iter().last().map(|fill| fill.to).unwrap();
 
             // The restrictions are all the same for a given label, so just take the first one
             let permit = fills[0].permit;

--- a/egress/src/lib.rs
+++ b/egress/src/lib.rs
@@ -17,6 +17,7 @@ use timeslice::{get_timeslice, Timeslice};
 use tokio_util::sync::CancellationToken;
 use tower_http::compression::CompressionLayer;
 
+use util::deserialize::comma_separated;
 use util::DbPools;
 
 pub mod auth;
@@ -90,10 +91,14 @@ pub struct LatestResp {
 
 #[derive(Debug, Deserialize)]
 struct PatchworkParams {
-    stationids: String,
-    paramids: String,
-    levels: String,
-    sensors: String,
+    #[serde(deserialize_with = "comma_separated")]
+    stationids: Vec<i32>,
+    #[serde(deserialize_with = "comma_separated")]
+    paramids: Vec<i32>,
+    #[serde(deserialize_with = "comma_separated")]
+    levels: Vec<i32>,
+    #[serde(deserialize_with = "comma_separated")]
+    sensors: Vec<i32>,
     from: DateTime<Utc>,
     to: DateTime<Utc>,
 }
@@ -190,33 +195,21 @@ async fn patchwork_handler(
     Query(params): Query<PatchworkParams>,
     Extension(roles): Extension<Option<Vec<i32>>>,
 ) -> Result<Json<Vec<PatchworkResp>>, (StatusCode, String)> {
-    // parse the strings from the query
-    // tried getting them to serialize as vec,
-    // but does not work for a list as well as being able to send one object
-    let stn_sep: Vec<&str> = params.stationids.split(",").collect(); // seperator used inside the string
-    let par_sep: Vec<&str> = params.paramids.split(",").collect(); // seperator used inside the string
-    let lev_sep: Vec<&str> = params.levels.split(",").collect(); // seperator used inside the string
-    let sen_sep: Vec<&str> = params.sensors.split(",").collect(); // seperator used inside the string
-
     let mut labels: Vec<PatchworkLabel> = Vec::new();
+
     // create a list of labels from the query parameters
     // (since they can send in one or more we need to loop)
-    for stn in stn_sep.iter() {
-        let station_id = stn.parse::<i32>().map_err(error::bad_request)?;
-        for par in par_sep.iter() {
-            let param_id = par.parse::<i32>().map_err(error::bad_request)?;
-            for lev in lev_sep.iter() {
-                let level = lev.parse::<i32>().map_err(error::bad_request)?;
-                for sen in sen_sep.iter() {
-                    let sensor = sen.parse::<i32>().map_err(error::bad_request)?;
+    for station_id in params.stationids {
+        for param_id in &params.paramids {
+            for level in &params.levels {
+                for sensor in &params.sensors {
                     let label =
-                        PatchworkLabel::new(station_id, param_id, Some(level), Some(sensor));
+                        PatchworkLabel::new(station_id, *param_id, Some(*level), Some(*sensor));
                     labels.push(label);
                 }
             }
         }
     }
-    //println!("Labels constructed: {labels:?}");
 
     let open_conn = pools.open.get().await.map_err(error::internal_error)?;
     let restricted_conn = pools

--- a/egress/src/lib.rs
+++ b/egress/src/lib.rs
@@ -244,7 +244,9 @@ async fn patchwork_handler(
             if !data.is_empty() {
                 // add to the outer list
                 patchwork_response.push(PatchworkResp { label, data });
-                continue; // found here so don't need to check the open
+
+                // found here so don't need to check the open
+                continue;
             }
         }
 

--- a/egress/src/lib.rs
+++ b/egress/src/lib.rs
@@ -278,28 +278,29 @@ async fn patchwork_handler(
 }
 
 pub async fn patchwork_available_handler(
-    State(patchwork_tables): State<PatchworkTables>,
+    State(tables): State<PatchworkTables>,
+    Extension(opt_roles): Extension<Option<Vec<i32>>>,
 ) -> Result<Json<PatchworkAvailableResp>, (StatusCode, String)> {
     let mut available_list: Vec<PatchworkAvailable> = Vec::new();
-    let ot = patchwork_tables
-        .open
-        .read()
-        .map_err(error::internal_error)?;
-    for (label, vec_fill) in ot.iter() {
+
+    let ot = tables.open.read().map_err(error::internal_error)?;
+
+    for (label, fills) in ot.iter() {
         // find first and last times
-        let first_time = vec_fill.iter().map(|item| item.from).min().unwrap();
-        let last_time = if vec_fill.iter().any(|item| item.to.is_none()) {
+        let first_time = fills.iter().map(|item| item.from).min().unwrap();
+        let last_time = if fills.iter().any(|item| item.to.is_none()) {
             // if there is a None to time, that means the series is open ended,
             // which is the latest possible to time. but Option's Ord impl
             // counts None as less than Some. So we have this if check to
             // override that behaviour
             None
         } else {
-            vec_fill.iter().map(|item| item.to).max().unwrap()
+            fills.iter().map(|item| item.to).max().unwrap()
         };
+
         // The restrictions are all the same for a given label, so just take the first one
-        let permit = vec_fill[0].permit;
-        // add to list
+        let permit = fills[0].permit;
+
         available_list.push(PatchworkAvailable {
             label: *label,
             from: first_time,
@@ -307,7 +308,35 @@ pub async fn patchwork_available_handler(
             permit,
         });
     }
-    // TODO: handle the restricted table bit maybe need to add which permit-ids the labels have?
+
+    if let Some(roles) = opt_roles {
+        let rt = tables.restricted.read().map_err(error::internal_error)?;
+
+        for (label, fills) in rt.iter() {
+            // Skip if request has wrong permits
+            if !fills.iter().any(|fill| roles.contains(&fill.permit)) {
+                continue;
+            }
+
+            let first_time = fills.iter().map(|fill| fill.from).min().unwrap();
+            let last_time = if fills.iter().any(|fill| fill.to.is_none()) {
+                // Same as in the comment above when iterating over open table
+                None
+            } else {
+                fills.iter().map(|fill| fill.to).max().unwrap()
+            };
+
+            // The restrictions are all the same for a given label, so just take the first one
+            let permit = fills[0].permit;
+
+            available_list.push(PatchworkAvailable {
+                label: *label,
+                from: first_time,
+                to: last_time,
+                permit,
+            });
+        }
+    }
 
     Ok(Json(PatchworkAvailableResp {
         available: available_list,

--- a/egress/src/lib.rs
+++ b/egress/src/lib.rs
@@ -19,18 +19,17 @@ use tower_http::compression::CompressionLayer;
 
 use util::DbPools;
 
-use patchwork::{get_patchwork, PatchworkDatum, PatchworkLabel, PatchworkTables};
-
-use auth::{auth_middleware, JWKScerts};
-
 pub mod auth;
 pub mod error;
 pub mod latest;
 pub mod patchwork;
 pub mod reports;
-
 pub mod timeseries;
 pub mod timeslice;
+
+use auth::{auth_middleware, JWKScerts};
+use patchwork::{get_patchwork, PatchworkDatum, PatchworkLabel, PatchworkTables};
+use reports::reports_router;
 
 // TODO: move to utils?
 type S3Bucket = Arc<s3::Bucket>;
@@ -339,7 +338,7 @@ pub async fn run(
         )
         .route("/patchwork/available", get(patchwork_available_handler))
         .route("/latest", get(latest_handler))
-        .nest("/reports", reports::set_routes())
+        .nest("/reports", reports_router())
         .with_state(EgressState {
             db_pools,
             s3_bucket,

--- a/egress/src/lib.rs
+++ b/egress/src/lib.rs
@@ -9,7 +9,6 @@ use axum::{
 };
 use chrono::{DateTime, Duration, Utc};
 use latest::{get_latest, LatestElem};
-use reports::reports_router;
 use serde::{Deserialize, Serialize};
 use timeseries::{
     get_timeseries_data_irregular, get_timeseries_data_regular, get_timeseries_info, Timeseries,
@@ -335,7 +334,7 @@ pub async fn run(
         )
         .route("/patchwork/available", get(patchwork_available_handler))
         .route("/latest", get(latest_handler))
-        .nest("/reports", reports_router())
+        .nest("/reports", reports::set_routes())
         .with_state(EgressState {
             db_pools,
             s3_bucket,

--- a/egress/src/lib.rs
+++ b/egress/src/lib.rs
@@ -230,7 +230,7 @@ async fn patchwork_handler(
     for label in labels {
         if roles.is_some() {
             // TODO: need to implement filtering based on allowed permits
-            let patchwork = get_patchwork(
+            let data = get_patchwork(
                 &restricted_conn,
                 params.from,
                 params.to,
@@ -240,13 +240,15 @@ async fn patchwork_handler(
             )
             .await
             .map_err(error::internal_error)?;
-            if let Some(data) = patchwork {
+
+            if !data.is_empty() {
                 // add to the outer list
                 patchwork_response.push(PatchworkResp { label, data });
                 continue; // found here so don't need to check the open
             }
         }
-        let patchwork = get_patchwork(
+
+        let data = get_patchwork(
             &open_conn,
             params.from,
             params.to,
@@ -256,7 +258,8 @@ async fn patchwork_handler(
         )
         .await
         .map_err(error::internal_error)?;
-        if let Some(data) = patchwork {
+
+        if !data.is_empty() {
             // add to the outer list
             patchwork_response.push(PatchworkResp { label, data });
         }

--- a/egress/src/main.rs
+++ b/egress/src/main.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use bb8_postgres::PostgresConnectionManager;
 use tokio_postgres::NoTls;
@@ -7,7 +7,7 @@ use tracing::{debug, error, info};
 
 use lard_egress::{
     error::Error,
-    patchwork::{self, PatchworkTimeseriesTables},
+    patchwork::{self, PatchworkTables},
 };
 use util::DbPools;
 
@@ -47,10 +47,10 @@ async fn main() -> Result<(), Error> {
     let restricted_conn = db_pools.restricted.get().await?;
     let patchwork_table_restricted =
         patchwork::fetch_patchwork_table(&restricted_conn, &stinfosys_client).await?;
-    let background_patchwork_tables = Arc::new(RwLock::new((
-        patchwork_table_open.clone(),
-        patchwork_table_restricted.clone(),
-    )));
+
+    let patchwork_tables = PatchworkTables::new(patchwork_table_open, patchwork_table_restricted);
+
+    let background_patchwork_tables = patchwork_tables.clone();
 
     // Cache the public key for checking tokens
     debug!("Caching the public key for authentication...");
@@ -76,9 +76,12 @@ async fn main() -> Result<(), Error> {
                     patchwork::fetch_patchwork_table(restricted_conn_loop, &stinfosys_client)
                         .await
                         .unwrap();
-                let mut table = background_patchwork_tables.write().unwrap();
-                table.0 = new_open_patchwork_table;
-                table.1 = new_restricted_patchwork_table;
+
+                let mut open_table = background_patchwork_tables.open.write().unwrap();
+                *open_table = new_open_patchwork_table;
+
+                let mut restricted_table = background_patchwork_tables.restricted.write().unwrap();
+                *restricted_table = new_restricted_patchwork_table;
             }
             .await;
         }
@@ -99,9 +102,6 @@ async fn main() -> Result<(), Error> {
     // set up cancellation token and signal catcher for graceful shutdown
     let cancel_token = CancellationToken::new();
     tokio::spawn(util::signal_catcher(cancel_token.clone()));
-
-    let patchwork_tables =
-        PatchworkTimeseriesTables::new(patchwork_table_open, patchwork_table_restricted);
 
     let egress_handle = tokio::spawn(lard_egress::run(
         db_pools.clone(),

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -46,17 +46,17 @@ pub struct Patch {
 }
 
 #[derive(Debug, Clone)]
-pub struct PatchworkTimeseriesTables {
+pub struct PatchworkTables {
     pub open: Arc<RwLock<PatchworkTimeseriesTable>>,
     pub restricted: Arc<RwLock<PatchworkTimeseriesTable>>,
 }
 
-impl PatchworkTimeseriesTables {
+impl PatchworkTables {
     pub fn new(
         open: PatchworkTimeseriesTable,
         restricted: PatchworkTimeseriesTable,
-    ) -> PatchworkTimeseriesTables {
-        PatchworkTimeseriesTables {
+    ) -> PatchworkTables {
+        PatchworkTables {
             open: Arc::new(RwLock::new(open)),
             restricted: Arc::new(RwLock::new(restricted)),
         }
@@ -69,7 +69,6 @@ pub struct MessagePriority {
     timerange: Timerange,
 }
 
-#[cfg(test)]
 impl MessagePriority {
     pub fn new(priority: i32, timerange: Timerange) -> MessagePriority {
         MessagePriority {
@@ -81,10 +80,10 @@ impl MessagePriority {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MetLabel {
-    id: TsID,
+    id: i64,
     station_id: i32,
-    param_id: ParamID,
-    type_id: TypeID,
+    param_id: i32,
+    type_id: i32,
     level: Option<i32>,
     sensor: Option<i32>,
 }
@@ -92,10 +91,10 @@ pub struct MetLabel {
 #[cfg(test)]
 impl MetLabel {
     pub fn new(
-        id: TsID,
+        id: i64,
         station_id: i32,
-        param_id: ParamID,
-        type_id: TypeID,
+        param_id: i32,
+        type_id: i32,
         level: Option<i32>,
         sensor: Option<i32>,
     ) -> MetLabel {
@@ -114,7 +113,7 @@ impl MetLabel {
 // essentially removing the type_id from the label
 pub struct PatchworkLabel {
     pub station_id: i32,
-    pub param_id: ParamID,
+    pub param_id: i32,
     pub level: Option<i32>,
     // TODO: should this be optional??
     pub sensor: Option<i32>,
@@ -123,7 +122,7 @@ pub struct PatchworkLabel {
 impl PatchworkLabel {
     pub fn new(
         station_id: i32,
-        param_id: ParamID,
+        param_id: i32,
         level: Option<i32>,
         sensor: Option<i32>,
     ) -> PatchworkLabel {
@@ -139,17 +138,17 @@ impl PatchworkLabel {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PriorityStruct {
     timerange: Timerange,
-    type_id: TypeID,
-    ts_id: TsID,
+    type_id: i32,
+    tsid: i64,
 }
 
 #[cfg(test)]
 impl PriorityStruct {
-    pub fn new(timerange: Timerange, type_id: TypeID, ts_id: TsID) -> PriorityStruct {
+    pub fn new(timerange: Timerange, type_id: i32, tsid: i64) -> PriorityStruct {
         PriorityStruct {
             timerange,
             type_id,
-            ts_id,
+            tsid,
         }
     }
 }
@@ -186,12 +185,7 @@ pub struct Fill {
 }
 
 impl Fill {
-    pub fn new(
-        from: DateTime<Utc>,
-        to: Option<DateTime<Utc>>,
-        tsid: TsID,
-        permit: PermitID,
-    ) -> Fill {
+    pub fn new(from: DateTime<Utc>, to: Option<DateTime<Utc>>, tsid: i64, permit: i32) -> Fill {
         Fill {
             from,
             to,
@@ -427,7 +421,9 @@ pub async fn fetch_patchwork_table(
     conn: &PooledPgConn<'_>,
     stinfosys_client: &Client,
 ) -> Result<PatchworkTimeseriesTable, Error> {
+    // TODO: this should be separate from the stinfosys stuff
     let db_ts_list = fetch_timeseries_list_from_database(conn).await?;
+
     let default_table = fetch_message_priority_default(stinfosys_client).await?;
     let exception_table = fetch_message_priority_exception(stinfosys_client).await?;
 

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -29,8 +29,6 @@ pub type MessagePriorityDefaultTable = HashMap<(TypeID, ParamID), MessagePriorit
 /// This table contains more specific exceptions to the default table
 /// for a patchwork label and typeid
 pub type MessagePriorityExceptionTable = HashMap<(PatchworkLabel, TypeID), MessagePriority>;
-// type for list of applicable timeseries
-pub type ApplicableTimeseriesList = Vec<Patch>;
 /// This table contains the patchworked timeseries, mapping to typeid and timeseriesid
 pub type PatchworkTimeseriesTable = HashMap<PatchworkLabel, Vec<Fill>>;
 
@@ -596,48 +594,40 @@ pub fn get_applicable_timeseries(
     to: DateTime<Utc>,
     label: PatchworkLabel,
     table: Arc<RwLock<PatchworkTimeseriesTable>>,
-) -> Result<Option<ApplicableTimeseriesList>, Error> {
+) -> Result<Vec<Patch>, Error> {
     // the table we are currenntly looking at (either open or closed)
     let t = table.read().map_err(|e| Error::Lock(e.to_string()))?;
-    let timeseries = t.get(&label);
+    let Some(timeseries) = t.get(&label) else {
+        // Label not found, therefore no timeseries are applicable
+        return Ok(vec![]);
+    };
 
-    // TODO: should this return error instead?
-    if timeseries.is_none() {
-        return Ok(None);
-    }
+    let request_fromto = Timerange {
+        from: Some(from),
+        to: Some(to),
+    };
 
     // TODO: if the label has none for sensor / level should it match on all???
     // create a structure to keep what is applicable
-    let mut applicable_ts: ApplicableTimeseriesList = vec![];
-    // fill the structure
-    for f in timeseries.unwrap() {
-        // is this applicable?
-        let ft = Timerange {
-            from: Some(from),
-            to: Some(to),
-        };
-        let overlap = ft.overlap(Timerange {
-            from: Some(f.from),
-            to: f.to,
-        });
-        // have overlap
-        if let Some(t) = overlap {
-            applicable_ts.push(Patch {
-                tsid: f.tsid,
-                permit_id: f.permit,
-                from: t.from.unwrap(),
-                to: t.to.unwrap_or(to),
-            });
-        }
-    }
+    let applicable_ts = timeseries
+        .iter()
+        .filter_map(|ts| {
+            let overlap = request_fromto.overlap(Timerange {
+                from: Some(ts.from),
+                to: ts.to,
+            })?;
 
-    // check if anything got put in the structure
-    // TODO: should this return error instead?
-    if applicable_ts.is_empty() {
-        return Ok(None);
-    }
+            Some(Patch {
+                tsid: ts.tsid,
+                permit_id: ts.permit,
+                from: overlap.from.unwrap(),
+                to: overlap.to.unwrap_or(to),
+            })
+        })
+        .collect();
 
-    Ok(Some(applicable_ts))
+    // TODO: should this return an error if empty?
+    Ok(applicable_ts)
 }
 
 pub async fn get_patchwork(
@@ -647,19 +637,15 @@ pub async fn get_patchwork(
     label: PatchworkLabel,
     table: Arc<RwLock<PatchworkTimeseriesTable>>,
     roles: Option<Vec<i32>>,
-) -> Result<Option<Vec<PatchworkDatum>>, Error> {
+) -> Result<Vec<PatchworkDatum>, Error> {
     // get ts that are applicable for this lable from the background patchwork table
     let applicable_ts = get_applicable_timeseries(from, to, label, table)?;
     let open_data: Vec<i32> = vec![1];
+    let unwrapped_roles = &roles.unwrap_or(open_data);
 
     let statement = conn
         .prepare(
-            "SELECT \
-                timeseries, \
-                obstime, \
-                original, \
-                corrected, \
-                quality_code \
+            "SELECT timeseries, obstime, original, corrected, quality_code \
             FROM legacy.data \
             WHERE timeseries = $1 \
                 AND obstime >= $2 \
@@ -667,45 +653,39 @@ pub async fn get_patchwork(
         )
         .await?;
 
-    match applicable_ts {
-        Some(ts) => {
-            let unwrapped_roles = &roles.unwrap_or(open_data);
-            let mut futures = ts
-                .iter()
-                .filter(|patch| patch.permit_id == 1 || unwrapped_roles.contains(&patch.permit_id))
-                .map(async |patch| {
-                    conn.query(&statement, &[&patch.tsid, &patch.from, &patch.to])
-                        .await
-                })
-                .collect::<FuturesOrdered<_>>()
-                .enumerate();
+    let mut futures = applicable_ts
+        .iter()
+        .filter(|patch| patch.permit_id == 1 || unwrapped_roles.contains(&patch.permit_id))
+        .map(async |patch| {
+            conn.query(&statement, &[&patch.tsid, &patch.from, &patch.to])
+                .await
+        })
+        .collect::<FuturesOrdered<_>>()
+        .enumerate();
 
-            let mut fails: Vec<usize> = Vec::new();
-            let mut data = Vec::new();
+    let mut fails: Vec<usize> = Vec::new();
+    let mut data = Vec::new();
 
-            while let Some((i, res)) = futures.next().await {
-                let rows = match res {
-                    Ok(val) => val,
-                    Err(_err) => {
-                        // TODO: need to log these fails
-                        fails.push(i);
-                        continue;
-                    }
-                };
-                for row in rows {
-                    data.push(PatchworkDatum {
-                        value: row.get(2),
-                        timestamp: row.get(1),
-                        corrected: row.get(3),
-                        quality_code: row.get(4),
-                    });
-                }
+    while let Some((i, res)) = futures.next().await {
+        let rows = match res {
+            Ok(val) => val,
+            Err(_err) => {
+                // TODO: need to log these fails
+                fails.push(i);
+                continue;
             }
-
-            Ok(Some(data))
+        };
+        for row in rows {
+            data.push(PatchworkDatum {
+                value: row.get(2),
+                timestamp: row.get(1),
+                corrected: row.get(3),
+                quality_code: row.get(4),
+            });
         }
-        None => Ok(None),
     }
+
+    Ok(data)
 }
 
 /*

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -622,17 +622,31 @@ pub async fn get_patchwork(
     let applicable_ts = get_applicable_timeseries(from, to, label, table)?;
     let open_data: Vec<i32> = vec![1];
 
+    let statement = conn
+        .prepare(
+            "SELECT \
+                timeseries, \
+                obstime, \
+                original, \
+                corrected, \
+                quality_code \
+            FROM legacy.data \
+            WHERE timeseries = $1 \
+                AND obstime >= $2 \
+                AND obstime < $3",
+        )
+        .await?;
+
     match applicable_ts {
         Some(ts) => {
             let unwrapped_roles = &roles.unwrap_or(open_data);
             let mut futures = ts
-                .iter().filter(|(_tsid, permit, _from, _to)| *permit == 1 || unwrapped_roles.contains(permit))
-                .map(|(tsid, _permit, from, to)| async move {
-                    let get_ts = format!(
-                    "SELECT timeseries, obstime, original, corrected, quality_code FROM legacy.data WHERE (timeseries = {tsid} \
-                        AND obstime >= '{from}' AND obstime < '{to}')",
-                    );
-                    conn.query(&get_ts, &[]).await
+                .iter()
+                .filter(|(_tsid, permit, _from, _to)| {
+                    *permit == 1 || unwrapped_roles.contains(permit)
+                })
+                .map(async |(tsid, _permit, from, to)| {
+                    conn.query(&statement, &[&tsid, &from, &to]).await
                 })
                 .collect::<FuturesOrdered<_>>()
                 .enumerate();

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -210,14 +210,14 @@ pub async fn fetch_message_priority_default(
 ) -> Result<MessagePriorityDefaultTable, Error> {
     let rows = client
         .query(
-            "SELECT 
-			mpd.message_formatid,
-			mpd.paramid,
-			mpd.priority,
-			mpd.fromtime,
-			mpd.totime
-		FROM message_priority_default mpd
-		ORDER BY message_formatid, paramid",
+            "SELECT \
+                mpd.message_formatid, \
+                mpd.paramid, \
+                mpd.priority, \
+                mpd.fromtime, \
+                mpd.totime \
+            FROM message_priority_default mpd \
+            ORDER BY message_formatid, paramid",
             &[],
         )
         .await?;
@@ -249,17 +249,17 @@ pub async fn fetch_message_priority_exception(
 ) -> Result<MessagePriorityExceptionTable, Error> {
     let rows = client
         .query(
-            "SELECT 
-			mpe.stationid,
-			mpe.message_formatid,
-			mpe.paramid,
-			mpe.hlevel,
-			mpe.sensor,
-			mpe.priority,
-			mpe.fromtime,
-			mpe.totime
-		FROM message_priority_exception mpe
-		ORDER BY stationid, message_formatid, paramid",
+            "SELECT \
+                mpe.stationid, \
+                mpe.message_formatid, \
+                mpe.paramid, \
+                mpe.hlevel, \
+                mpe.sensor, \
+                mpe.priority, \
+                mpe.fromtime, \
+                mpe.totime \
+            FROM message_priority_exception mpe \
+            ORDER BY stationid, message_formatid, paramid",
             &[],
         )
         .await?;
@@ -300,9 +300,20 @@ pub async fn fetch_timeseries_list_from_database(
     // NOTE: currently skipping null param ids that we plan to remove in the future
     let data_results = conn
         .query(
-            "SELECT l.timeseries, l.station_id, l.param_id, l.type_id, 
-            l.lvl, l.sensor, t.fromtime, t.totime, t.permit from labels.Met l 
-            JOIN timeseries t on t.id=l.timeseries where l.param_id is not null",
+            "SELECT \
+                l.timeseries, \
+                l.station_id, \
+                l.param_id, \
+                l.type_id, \
+                l.lvl, \
+                l.sensor, \
+                t.fromtime, \
+                t.totime, \
+                t.permit \
+            FROM labels.met l \
+            JOIN timeseries t \
+                ON t.id = l.timeseries \
+            WHERE l.param_id is not null",
             &[],
         )
         .await?;

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -115,8 +115,8 @@ impl MetLabel {
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash)]
 // essentially removing the type_id from the label
 pub struct PatchworkLabel {
-    station_id: i32,
-    param_id: ParamID,
+    pub station_id: i32,
+    pub param_id: ParamID,
     level: Option<i32>,
     // TODO: should this be optional??
     sensor: Option<i32>,

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -40,7 +40,7 @@ type TsID = i64;
 
 pub struct Patch {
     pub tsid: TsID,
-    pub permit_id: i32,
+    pub permit_id: ParamID,
     pub from: DateTime<Utc>,
     pub to: DateTime<Utc>,
 }
@@ -80,10 +80,10 @@ impl MessagePriority {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MetLabel {
-    id: i64,
+    id: TsID,
     station_id: i32,
-    param_id: i32,
-    type_id: i32,
+    param_id: ParamID,
+    type_id: TypeID,
     level: Option<i32>,
     sensor: Option<i32>,
 }
@@ -91,10 +91,10 @@ pub struct MetLabel {
 #[cfg(test)]
 impl MetLabel {
     pub fn new(
-        id: i64,
+        id: TsID,
         station_id: i32,
-        param_id: i32,
-        type_id: i32,
+        param_id: ParamID,
+        type_id: TypeID,
         level: Option<i32>,
         sensor: Option<i32>,
     ) -> MetLabel {
@@ -113,7 +113,7 @@ impl MetLabel {
 // essentially removing the type_id from the label
 pub struct PatchworkLabel {
     pub station_id: i32,
-    pub param_id: i32,
+    pub param_id: ParamID,
     pub level: Option<i32>,
     // TODO: should this be optional??
     pub sensor: Option<i32>,
@@ -122,7 +122,7 @@ pub struct PatchworkLabel {
 impl PatchworkLabel {
     pub fn new(
         station_id: i32,
-        param_id: i32,
+        param_id: ParamID,
         level: Option<i32>,
         sensor: Option<i32>,
     ) -> PatchworkLabel {
@@ -138,13 +138,13 @@ impl PatchworkLabel {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PriorityStruct {
     timerange: Timerange,
-    type_id: i32,
-    tsid: i64,
+    type_id: TypeID,
+    tsid: TsID,
 }
 
 #[cfg(test)]
 impl PriorityStruct {
-    pub fn new(timerange: Timerange, type_id: i32, tsid: i64) -> PriorityStruct {
+    pub fn new(timerange: Timerange, type_id: TypeID, tsid: TsID) -> PriorityStruct {
         PriorityStruct {
             timerange,
             type_id,

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -642,13 +642,14 @@ pub async fn get_patchwork(
     let open_data: Vec<i32> = vec![1];
     let unwrapped_roles = &roles.unwrap_or(open_data);
 
-    let statement = conn
+    let query = conn
         .prepare(
             "SELECT timeseries, obstime, original, corrected, quality_code \
             FROM legacy.data \
             WHERE timeseries = $1 \
                 AND obstime >= $2 \
-                AND obstime < $3",
+                AND obstime < $3 \
+            ORDER BY obstime",
         )
         .await?;
 
@@ -656,7 +657,7 @@ pub async fn get_patchwork(
         .iter()
         .filter(|patch| patch.permit_id == 1 || unwrapped_roles.contains(&patch.permit_id))
         .map(async |patch| {
-            conn.query(&statement, &[&patch.tsid, &patch.from, &patch.to])
+            conn.query(&query, &[&patch.tsid, &patch.from, &patch.to])
                 .await
         })
         .collect::<FuturesOrdered<_>>()

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -585,10 +585,13 @@ pub fn create_patchwork_timeseries_table(
     Ok(patchwork)
 }
 
+/// Checks if the given `label` exists in the patchwork `table` and extracts a vector of time
+/// sorted timeseries patches given the bounds of the input `from` and `to` times
 pub fn get_applicable_timeseries(
     from: DateTime<Utc>,
     to: DateTime<Utc>,
     label: PatchworkLabel,
+    roles: &[i32],
     table: Arc<RwLock<PatchworkTimeseriesTable>>,
 ) -> Result<Vec<Patch>, Error> {
     // the table we are currenntly looking at (either open or closed)
@@ -605,8 +608,9 @@ pub fn get_applicable_timeseries(
 
     // TODO: if the label has none for sensor / level should it match on all???
     // create a structure to keep what is applicable
-    let applicable_ts = timeseries
+    let mut applicable_ts: Vec<_> = timeseries
         .iter()
+        .filter(|ts| ts.permit == 1 || roles.contains(&ts.permit))
         .filter_map(|ts| {
             let overlap = request_fromto.overlap(Timerange {
                 from: Some(ts.from),
@@ -635,12 +639,16 @@ pub async fn get_patchwork(
     to: DateTime<Utc>,
     label: PatchworkLabel,
     table: Arc<RwLock<PatchworkTimeseriesTable>>,
-    roles: Option<Vec<i32>>,
+    opt_roles: Option<Vec<i32>>,
 ) -> Result<Vec<PatchworkDatum>, Error> {
+    let roles = opt_roles.unwrap_or_default();
+
     // get ts that are applicable for this lable from the background patchwork table
-    let applicable_ts = get_applicable_timeseries(from, to, label, table)?;
-    let open_data: Vec<i32> = vec![1];
-    let unwrapped_roles = &roles.unwrap_or(open_data);
+    let applicable_ts = get_applicable_timeseries(from, to, label, &roles, table)?;
+
+    if applicable_ts.is_empty() {
+        return Ok(vec![]);
+    }
 
     let query = conn
         .prepare(
@@ -655,7 +663,6 @@ pub async fn get_patchwork(
 
     let mut futures = applicable_ts
         .iter()
-        .filter(|patch| patch.permit_id == 1 || unwrapped_roles.contains(&patch.permit_id))
         .map(async |patch| {
             conn.query(&query, &[&patch.tsid, &patch.from, &patch.to])
                 .await

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -111,6 +111,7 @@ pub struct PatchworkLabel {
     station_id: i32,
     param_id: ParamID,
     level: Option<i32>,
+    // TODO: should this be optional??
     sensor: Option<i32>,
 }
 
@@ -149,7 +150,7 @@ impl PriorityStruct {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct PatchworkData {
+pub struct PatchworkDatum {
     // can assume have a value and timestamp? (the field for original value can be null...)
     // but do not always have corrected and quality code
     value: f64,
@@ -581,9 +582,12 @@ pub fn get_applicable_timeseries(
     // the table we are currenntly looking at (either open or closed)
     let t = table.read().map_err(|e| Error::Lock(e.to_string()))?;
     let timeseries = t.get(&label);
+
+    // TODO: should this return error instead?
     if timeseries.is_none() {
         return Ok(None);
     }
+
     // TODO: if the label has none for sensor / level should it match on all???
     // create a structure to keep what is applicable
     let mut applicable_ts: ApplicableTimeseriesList = vec![];
@@ -603,10 +607,13 @@ pub fn get_applicable_timeseries(
             applicable_ts.push((f.tsid, f.permit, t.from.unwrap(), t.to.unwrap_or(to)));
         }
     }
+
     // check if anything got put in the structure
+    // TODO: should this return error instead?
     if applicable_ts.is_empty() {
         return Ok(None);
     }
+
     Ok(Some(applicable_ts))
 }
 
@@ -617,7 +624,7 @@ pub async fn get_patchwork(
     label: PatchworkLabel,
     table: Arc<RwLock<PatchworkTimeseriesTable>>,
     roles: Option<Vec<i32>>,
-) -> Result<Option<Vec<PatchworkData>>, Error> {
+) -> Result<Option<Vec<PatchworkDatum>>, Error> {
     // get ts that are applicable for this lable from the background patchwork table
     let applicable_ts = get_applicable_timeseries(from, to, label, table)?;
     let open_data: Vec<i32> = vec![1];
@@ -664,7 +671,7 @@ pub async fn get_patchwork(
                     }
                 };
                 for row in rows {
-                    data.push(PatchworkData {
+                    data.push(PatchworkDatum {
                         value: row.get(2),
                         timestamp: row.get(1),
                         corrected: row.get(3),

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use tokio_postgres::Client;
 use tracing::warn;
-use util::{DbPools, PgPool, PooledPgConn};
+use util::PooledPgConn;
 
 /// This table is where to look for the timeseries priority
 /// for a given typeid and paramid
@@ -583,26 +583,6 @@ pub fn create_patchwork_timeseries_table(
         list.sort_by_key(|item| (item.from));
     }
     Ok(patchwork)
-}
-
-// Utility function that returns applicable timeseries patches and the correct pool
-pub async fn get_patches(
-    from: DateTime<Utc>,
-    to: DateTime<Utc>,
-    label: PatchworkLabel,
-    tables: PatchworkTables,
-    pools: DbPools,
-    roles: Option<Vec<i32>>,
-) -> Result<(Vec<Patch>, PgPool), Error> {
-    if roles.is_some() {
-        let patches = get_applicable_timeseries(from, to, label, tables.restricted)?;
-        if !patches.is_empty() {
-            return Ok((patches, pools.restricted));
-        }
-    };
-
-    let patches = get_applicable_timeseries(from, to, label, tables.open)?;
-    Ok((patches, pools.open))
 }
 
 pub fn get_applicable_timeseries(

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -622,6 +622,9 @@ pub fn get_applicable_timeseries(
         })
         .collect();
 
+    // Sort with fromtime since we want to serve data from oldest to latest
+    applicable_ts.sort_by_key(|fill| fill.from);
+
     // TODO: should this return an error if empty?
     Ok(applicable_ts)
 }

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -585,6 +585,23 @@ pub fn create_patchwork_timeseries_table(
     Ok(patchwork)
 }
 
+pub fn get_patches(
+    from: DateTime<Utc>,
+    to: DateTime<Utc>,
+    label: PatchworkLabel,
+    tables: PatchworkTables,
+    roles: Option<Vec<i32>>,
+) -> Result<Vec<Patch>, Error> {
+    if roles.is_some() {
+        let patches = get_applicable_timeseries(from, to, label, tables.restricted)?;
+        if !patches.is_empty() {
+            return Ok(patches);
+        }
+    };
+
+    get_applicable_timeseries(from, to, label, tables.open)
+}
+
 pub fn get_applicable_timeseries(
     from: DateTime<Utc>,
     to: DateTime<Utc>,

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -30,7 +30,7 @@ pub type MessagePriorityDefaultTable = HashMap<(TypeID, ParamID), MessagePriorit
 /// for a patchwork label and typeid
 pub type MessagePriorityExceptionTable = HashMap<(PatchworkLabel, TypeID), MessagePriority>;
 // type for list of applicable timeseries
-pub type ApplicableTimeseriesList = Vec<(TsID, PermitID, DateTime<Utc>, DateTime<Utc>)>;
+pub type ApplicableTimeseriesList = Vec<Patch>;
 /// This table contains the patchworked timeseries, mapping to typeid and timeseriesid
 pub type PatchworkTimeseriesTable = HashMap<PatchworkLabel, Vec<Fill>>;
 
@@ -39,6 +39,13 @@ type TypeID = i32;
 type ParamID = i32;
 type PermitID = i32;
 type TsID = i64;
+
+pub struct Patch {
+    pub tsid: TsID,
+    pub permit_id: i32,
+    pub from: DateTime<Utc>,
+    pub to: DateTime<Utc>,
+}
 
 #[derive(Debug, Clone)]
 pub struct PatchworkTimeseriesTables {
@@ -604,7 +611,12 @@ pub fn get_applicable_timeseries(
         });
         // have overlap
         if let Some(t) = overlap {
-            applicable_ts.push((f.tsid, f.permit, t.from.unwrap(), t.to.unwrap_or(to)));
+            applicable_ts.push(Patch {
+                tsid: f.tsid,
+                permit_id: f.permit,
+                from: t.from.unwrap(),
+                to: t.to.unwrap_or(to),
+            });
         }
     }
 
@@ -649,11 +661,10 @@ pub async fn get_patchwork(
             let unwrapped_roles = &roles.unwrap_or(open_data);
             let mut futures = ts
                 .iter()
-                .filter(|(_tsid, permit, _from, _to)| {
-                    *permit == 1 || unwrapped_roles.contains(permit)
-                })
-                .map(async |(tsid, _permit, from, to)| {
-                    conn.query(&statement, &[&tsid, &from, &to]).await
+                .filter(|patch| patch.permit_id == 1 || unwrapped_roles.contains(&patch.permit_id))
+                .map(async |patch| {
+                    conn.query(&statement, &[&patch.tsid, &patch.from, &patch.to])
+                        .await
                 })
                 .collect::<FuturesOrdered<_>>()
                 .enumerate();

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -608,7 +608,7 @@ pub fn get_applicable_timeseries(
 
     // TODO: if the label has none for sensor / level should it match on all???
     // create a structure to keep what is applicable
-    let mut applicable_ts: Vec<_> = timeseries
+    let applicable_ts: Vec<_> = timeseries
         .iter()
         .filter(|ts| ts.permit == 1 || roles.contains(&ts.permit))
         .filter_map(|ts| {
@@ -625,9 +625,6 @@ pub fn get_applicable_timeseries(
             })
         })
         .collect();
-
-    // Sort with fromtime since we want to serve data from oldest to latest
-    applicable_ts.sort_by_key(|fill| fill.from);
 
     // TODO: should this return an error if empty?
     Ok(applicable_ts)

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -117,9 +117,9 @@ impl MetLabel {
 pub struct PatchworkLabel {
     pub station_id: i32,
     pub param_id: ParamID,
-    level: Option<i32>,
+    pub level: Option<i32>,
     // TODO: should this be optional??
-    sensor: Option<i32>,
+    pub sensor: Option<i32>,
 }
 
 impl PatchworkLabel {

--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use tokio_postgres::Client;
 use tracing::warn;
-use util::PooledPgConn;
+use util::{DbPools, PgPool, PooledPgConn};
 
 /// This table is where to look for the timeseries priority
 /// for a given typeid and paramid
@@ -585,21 +585,24 @@ pub fn create_patchwork_timeseries_table(
     Ok(patchwork)
 }
 
-pub fn get_patches(
+// Utility function that returns applicable timeseries patches and the correct pool
+pub async fn get_patches(
     from: DateTime<Utc>,
     to: DateTime<Utc>,
     label: PatchworkLabel,
     tables: PatchworkTables,
+    pools: DbPools,
     roles: Option<Vec<i32>>,
-) -> Result<Vec<Patch>, Error> {
+) -> Result<(Vec<Patch>, PgPool), Error> {
     if roles.is_some() {
         let patches = get_applicable_timeseries(from, to, label, tables.restricted)?;
         if !patches.is_empty() {
-            return Ok(patches);
+            return Ok((patches, pools.restricted));
         }
     };
 
-    get_applicable_timeseries(from, to, label, tables.open)
+    let patches = get_applicable_timeseries(from, to, label, tables.open)?;
+    Ok((patches, pools.open))
 }
 
 pub fn get_applicable_timeseries(

--- a/egress/src/reports.rs
+++ b/egress/src/reports.rs
@@ -4,6 +4,7 @@ use crate::EgressState;
 
 mod idf_event;
 use idf_event::{idf_event_availability_handler, idf_event_handler};
+pub use idf_event::{IdfEvent, IdfEventAvailability, IdfEventResp, DEFAULT_DURATIONS};
 
 mod idf_station;
 use idf_station::{idf_station_availability_handler, idf_station_handler};
@@ -13,7 +14,6 @@ pub fn set_routes() -> Router<EgressState> {
     Router::new()
         .route("/idf/station", get(idf_station_availability_handler))
         .route("/idf/station/{station_id}", get(idf_station_handler))
-        // TODO: add route to query all available stations with PT1M precipitation observations?
         .route("/idf/event", get(idf_event_availability_handler))
         .route("/idf/event/{station_id}", get(idf_event_handler))
 }

--- a/egress/src/reports.rs
+++ b/egress/src/reports.rs
@@ -4,7 +4,9 @@ use crate::EgressState;
 
 mod idf_event;
 use idf_event::{idf_event_availability_handler, idf_event_handler};
-pub use idf_event::{IdfEvent, IdfEventAvailabilityResp, IdfEventResp, DEFAULT_DURATIONS};
+pub use idf_event::{
+    IdfEvent, IdfEventAvailabilityResp, IdfEventAvailable, IdfEventResp, DEFAULT_DURATIONS,
+};
 
 mod idf_station;
 use idf_station::{idf_station_availability_handler, idf_station_handler};

--- a/egress/src/reports.rs
+++ b/egress/src/reports.rs
@@ -10,7 +10,7 @@ mod idf_station;
 use idf_station::{idf_station_availability_handler, idf_station_handler};
 pub use idf_station::{IdfMetadata, IdfStationAvailability, IdfStationResp, IdfUnit, IdfValue};
 
-pub fn set_routes() -> Router<EgressState> {
+pub fn reports_router() -> Router<EgressState> {
     Router::new()
         .route("/idf/station", get(idf_station_availability_handler))
         .route("/idf/station/{station_id}", get(idf_station_handler))

--- a/egress/src/reports.rs
+++ b/egress/src/reports.rs
@@ -4,7 +4,7 @@ use crate::EgressState;
 
 mod idf_event;
 use idf_event::{idf_event_availability_handler, idf_event_handler};
-pub use idf_event::{IdfEvent, IdfEventAvailability, IdfEventResp, DEFAULT_DURATIONS};
+pub use idf_event::{IdfEvent, IdfEventAvailabilityResp, IdfEventResp, DEFAULT_DURATIONS};
 
 mod idf_station;
 use idf_station::{idf_station_availability_handler, idf_station_handler};

--- a/egress/src/reports.rs
+++ b/egress/src/reports.rs
@@ -2,6 +2,9 @@ use axum::{routing::get, Router};
 
 use crate::EgressState;
 
+mod idf_event;
+use idf_event::idf_event_handler;
+
 mod idf_station;
 use idf_station::{idf_station_availability_handler, idf_station_handler};
 pub use idf_station::{IdfMetadata, IdfStationAvailability, IdfStationResp, IdfUnit, IdfValue};
@@ -10,4 +13,6 @@ pub fn reports_router() -> Router<EgressState> {
     Router::new()
         .route("/idf/station", get(idf_station_availability_handler))
         .route("/idf/station/{station_id}", get(idf_station_handler))
+        // TODO: add route to query all available stations with PT1M precipitation observations?
+        .route("/idf/event/{station_id}", get(idf_event_handler))
 }

--- a/egress/src/reports.rs
+++ b/egress/src/reports.rs
@@ -9,7 +9,7 @@ mod idf_station;
 use idf_station::{idf_station_availability_handler, idf_station_handler};
 pub use idf_station::{IdfMetadata, IdfStationAvailability, IdfStationResp, IdfUnit, IdfValue};
 
-pub fn reports_router() -> Router<EgressState> {
+pub fn set_routes() -> Router<EgressState> {
     Router::new()
         .route("/idf/station", get(idf_station_availability_handler))
         .route("/idf/station/{station_id}", get(idf_station_handler))

--- a/egress/src/reports.rs
+++ b/egress/src/reports.rs
@@ -3,7 +3,7 @@ use axum::{routing::get, Router};
 use crate::EgressState;
 
 mod idf_event;
-use idf_event::idf_event_handler;
+use idf_event::{idf_event_availability_handler, idf_event_handler};
 
 mod idf_station;
 use idf_station::{idf_station_availability_handler, idf_station_handler};
@@ -14,5 +14,6 @@ pub fn set_routes() -> Router<EgressState> {
         .route("/idf/station", get(idf_station_availability_handler))
         .route("/idf/station/{station_id}", get(idf_station_handler))
         // TODO: add route to query all available stations with PT1M precipitation observations?
+        .route("/idf/event", get(idf_event_availability_handler))
         .route("/idf/event/{station_id}", get(idf_event_handler))
 }

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -11,6 +11,7 @@ use util::{deserialize::optional_comma_separated, DbPools, PooledPgConn};
 use crate::{
     error::{internal_error, Error},
     patchwork::{self, Patch, PatchworkLabel, PatchworkTimeseriesTables},
+    reports::idf_station::mm_to_lsha,
 };
 
 use super::idf_station::IdfUnit;
@@ -118,7 +119,7 @@ async fn fetch_rain_data(
 }
 
 /// Computes the IDF event for the input `duration` using the precipitation `data` fetched from LARD.
-fn calculate_idf_event(duration: u32, data: &[RainfallDatum]) -> IdfEvent {
+fn calculate_idf_event(duration: u32, data: &[RainfallDatum], unit: IdfUnit) -> IdfEvent {
     let mut maximum = IdfEvent {
         duration,
         fromtime: DateTime::default(),
@@ -147,14 +148,18 @@ fn calculate_idf_event(duration: u32, data: &[RainfallDatum]) -> IdfEvent {
         }
     }
 
+    if unit == IdfUnit::Lsha {
+        maximum.intensity = mm_to_lsha(maximum.intensity, duration)
+    }
+
     maximum
 }
 
 // TODO: should spawn in separate thread and use par_iter instead of into_iter?
-fn collect_idf_events(durations: &[u32], data: Vec<RainfallDatum>) -> Vec<IdfEvent> {
+fn collect_idf_events(durations: &[u32], data: Vec<RainfallDatum>, unit: IdfUnit) -> Vec<IdfEvent> {
     durations
         .iter()
-        .map(|&duration| calculate_idf_event(duration, &data))
+        .map(|&duration| calculate_idf_event(duration, &data, unit))
         .collect()
 }
 
@@ -209,7 +214,7 @@ pub async fn idf_event_handler(
     });
 
     let durations = inputs.as_deref().unwrap_or(DEFAULT_DURATIONS);
-    let values = collect_idf_events(durations, data);
+    let values = collect_idf_events(durations, data, params.unit);
 
     Ok(Json(IdfEventResp {
         station_id,
@@ -338,7 +343,7 @@ mod tests {
             },
         ];
 
-        let values: Vec<_> = collect_idf_events(&durations, data);
+        let values: Vec<_> = collect_idf_events(&durations, data, IdfUnit::Mm);
 
         assert_eq!(values.len(), expected.len());
 

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -1,7 +1,7 @@
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
-    Json,
+    Extension, Json,
 };
 use chrono::{DateTime, TimeDelta, Utc};
 use futures::{stream::FuturesOrdered, StreamExt};
@@ -188,6 +188,7 @@ pub async fn idf_event_handler(
     State(pools): State<DbPools>,
     State(tables): State<PatchworkTables>,
     Query(params): Query<IdfEventParams>,
+    Extension(roles): Extension<Option<Vec<i32>>>,
 ) -> Result<Json<IdfEventResp>, (StatusCode, String)> {
     let idf_event_label = PatchworkLabel::new(
         station_id,
@@ -196,12 +197,12 @@ pub async fn idf_event_handler(
         DEFAULT_SENSOR,
     );
 
-    let patches = patchwork::get_applicable_timeseries(
+    let patches = patchwork::get_patches(
         params.fromtime,
         params.totime,
         idf_event_label,
-        tables.open,
-        Some(tables.restricted),
+        tables,
+        roles,
     )
     .map_err(internal_error)?;
 

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -197,13 +197,15 @@ pub async fn idf_event_handler(
         DEFAULT_SENSOR,
     );
 
-    let patches = patchwork::get_patches(
+    let (patches, pool) = patchwork::get_patches(
         params.fromtime,
         params.totime,
         idf_event_label,
         tables,
+        pools,
         roles,
     )
+    .await
     .map_err(internal_error)?;
 
     if patches.is_empty() {
@@ -214,7 +216,7 @@ pub async fn idf_event_handler(
     };
 
     // TODO: this should be handled by auth
-    let conn = pools.open.get().await.map_err(internal_error)?;
+    let conn = pool.get().await.map_err(internal_error)?;
 
     let data = fetch_rain_data(patches, &conn)
         .await

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use util::{deserialize::optional_comma_separated, DbPools, PooledPgConn};
 
 use crate::{
-    error::{internal_error, not_found_error, Error},
+    error::{internal_error, Error},
     patchwork::{self, Patch, PatchworkLabel, PatchworkTimeseriesTables},
 };
 
@@ -180,9 +180,13 @@ pub async fn idf_event_handler(
         tables.open,
         Some(tables.restricted),
     )
-    .map_err(not_found_error)?
-    // TODO: this should not return an option?
-    .unwrap();
+    .map_err(internal_error)?
+    .ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            "No applicable timeseries in the given time period".to_string(),
+        )
+    })?;
 
     // TODO: this should be handled by auth
     let conn = pools.open.get().await.map_err(internal_error)?;

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -223,7 +221,14 @@ pub async fn idf_event_handler(
 /// Response struct returned by the availability endpoint
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdfEventAvailability {
-    pub stations: HashSet<i32>,
+    /// List of stations for which IDF calculation is possible
+    pub stations: Vec<i32>,
+}
+
+fn is_idf_event_timeseries(label: &PatchworkLabel) -> bool {
+    label.param_id == PRECIPITATION_PARAM_ID
+        && label.level == DEFAULT_LEVEL
+        && label.sensor == DEFAULT_SENSOR
 }
 
 pub async fn idf_event_availability_handler(
@@ -233,9 +238,10 @@ pub async fn idf_event_availability_handler(
     let ot = patchwork_tables.open.read().map_err(internal_error)?;
 
     // TODO: not sure how performant this is, maybe faster to check the DB?
-    let stations: HashSet<_> = ot
+    // Or we need a different datastructure
+    let stations = ot
         .keys()
-        .filter(|label| label.param_id == PRECIPITATION_PARAM_ID)
+        .filter(|label| is_idf_event_timeseries(label))
         .map(|label| label.station_id)
         .collect();
 

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -92,19 +92,19 @@ struct RainfallDatum {
     value: f64,
 }
 
-// Fetches rainfall observations given the vector of timeseries patches
+/// Fetches rainfall observations given the vector of timeseries patches
 async fn fetch_rain_data(
     label: PatchworkLabel,
     params: &IdfEventParams,
     roles: &[i32],
     pool: PgPool,
     table: Arc<RwLock<PatchworkTimeseriesTable>>,
-) -> Result<Option<Vec<RainfallDatum>>, Error> {
+) -> Result<Vec<RainfallDatum>, Error> {
     let patches =
         patchwork::get_applicable_timeseries(params.fromtime, params.totime, label, roles, table)?;
 
     if patches.is_empty() {
-        return Ok(None);
+        return Ok(vec![]);
     }
 
     let conn = pool.get().await?;
@@ -146,7 +146,7 @@ async fn fetch_rain_data(
         }
     }
 
-    Ok(Some(data))
+    Ok(data)
 }
 
 /// Computes the IDF event (maximum sum of precipitation intensities over windows of
@@ -209,32 +209,24 @@ pub async fn idf_event_handler(
         DEFAULT_SENSOR,
     );
 
-    let data = {
-        let open = fetch_rain_data(idf_label, &params, &[], pools.open, tables.open)
-            .await
-            .map_err(internal_error)?;
+    let r = roles.unwrap_or_default();
+    let (open_data, restricted_data) = tokio::try_join!(
+        fetch_rain_data(idf_label, &params, &r, pools.open, tables.open),
+        fetch_rain_data(idf_label, &params, &r, pools.restricted, tables.restricted),
+    )
+    .map_err(internal_error)?;
 
-        match open {
-            Some(data) => Some(data),
-            None => match roles {
-                Some(r) => {
-                    fetch_rain_data(idf_label, &params, &r, pools.restricted, tables.restricted)
-                        .await
-                        .map_err(internal_error)?
-                }
-                None => {
-                    return Err((
-                        StatusCode::NOT_FOUND,
-                        "No applicable timeseries in the given time period".to_string(),
-                    ))
-                }
-            },
+    // NOTE: given how permits work at the moment, these are mutually exclusive
+    let data = match (open_data.is_empty(), restricted_data.is_empty()) {
+        (false, _) => open_data,
+        (_, false) => restricted_data,
+        (true, true) => {
+            return Err((
+                StatusCode::NOT_FOUND,
+                "no data found for this station".to_string(),
+            ))
         }
-    }
-    .ok_or((
-        StatusCode::NOT_FOUND,
-        format!("No precipitation data found for station {station_id}"),
-    ))?;
+    };
 
     // We allow any provided duration that is less or equal to `MAX_ALLOWED_DURATION`
     let inputs: Option<Vec<u32>> = params.durations.map(|values| {
@@ -273,9 +265,8 @@ pub async fn idf_event_availability_handler(
 ) -> Result<Json<IdfEventAvailability>, (StatusCode, String)> {
     let ot = tables.open.read().map_err(internal_error)?;
 
-    // TODO: not sure how performant this is, maybe faster to check the DB?
-    // Or we need a different datastructure
-    // TODO: add timeranges for the different stations ?
+    // TODO: not sure how performant this is, maybe we need a different data structure?
+    // TODO: add timeranges and permits for the different stations?
     let mut stations: Vec<_> = ot
         .keys()
         .filter(|label| is_idf_event_timeseries(label))

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -73,27 +73,33 @@ struct RainfallDatum {
     value: f64,
 }
 
-/// Fetches all rainfall observations given the vector of timeseries patches
-// TODO: this is an adapted version of get_patchwork with two more WHERE conditions.
-// Are we fine having separate "patchwork" queries for specific tasks?
+/// Fetches rainfall observations given the vector of timeseries patches
 async fn fetch_rain_data(
     patches: Vec<Patch>,
     conn: &PooledPgConn<'_>,
 ) -> Result<Vec<RainfallDatum>, Error> {
-    // TODO: are these timeseries ordered by fromtime?
-    let mut futures = patches
-        .iter()
-        .map(|patch| async move {
-            conn.query(
-                "SELECT obstime, corrected \
+    // The IDF event calculation requires
+    // - data that has been QCed (lines with `corrected`)
+    // - non erroneous data (quality_code != 7)
+    let stmt = conn
+        .prepare(
+            "SELECT obstime, corrected \
                 FROM legacy.data \
                 WHERE timeseries = $1 \
                     AND corrected IS NOT NULL \
+                    AND corrected > -30000.0 \
                     AND quality_code != 7 \
-                    AND obstime BETWEEN $2 AND $3",
-                &[&patch.tsid, &patch.from, &patch.to],
-            )
-            .await
+                    AND obstime BETWEEN $2 AND $3
+                ORDER BY obstime",
+        )
+        .await?;
+
+    // TODO: are these patches ordered by fromtime?
+    let mut futures = patches
+        .iter()
+        .map(|patch| async {
+            conn.query(&stmt, &[&patch.tsid, &patch.from, &patch.to])
+                .await
         })
         .collect::<FuturesOrdered<_>>();
 

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -5,7 +5,7 @@ use axum::{
     http::StatusCode,
     Extension, Json,
 };
-use chrono::{DateTime, TimeDelta, Utc};
+use chrono::{DateTime, Duration, Utc};
 use futures::{stream::FuturesOrdered, StreamExt};
 use serde::{Deserialize, Serialize};
 use util::{deserialize::optional_comma_separated, DbPools, PgPool};
@@ -161,7 +161,7 @@ fn calculate_idf_event(duration: u32, data: &[RainfallDatum], unit: IdfUnit) -> 
     // NOTE: unfortunately we can't use a window iterator because the data is not regular
     for (i, val) in data.iter().enumerate() {
         let start_time = val.timestamp;
-        let cutoff_time = start_time + TimeDelta::minutes(duration as i64);
+        let cutoff_time = start_time + Duration::minutes(duration as i64);
 
         // Manually compute the sum of intensities using only observations that fall
         // before the given cutoff time

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -149,7 +149,8 @@ async fn fetch_rain_data(
     Ok(Some(data))
 }
 
-/// Computes the IDF event for the input `duration` using the precipitation `data` fetched from LARD.
+/// Computes the IDF event (maximum sum of precipitation intensities over windows of
+/// a given duration) for the input `duration` using the precipitation `data` fetched from LARD.
 fn calculate_idf_event(duration: u32, data: &[RainfallDatum], unit: IdfUnit) -> IdfEvent {
     let mut maximum = IdfEvent {
         duration,

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -9,16 +9,20 @@ use serde::{Deserialize, Serialize};
 use util::{DbPools, PooledPgConn};
 
 use crate::{
-    error::{self, internal_error, not_found_error},
-    patchwork::{get_applicable_timeseries, PatchworkLabel, PatchworkTimeseriesTables},
+    error::{self, internal_error, not_found_error, Error},
+    patchwork::{self, Patch, PatchworkLabel, PatchworkTimeseriesTables},
 };
 
 use super::idf_station::IdfUnit;
 
+// sum(precipitation_amount PT1M)
 const PRECIPITATION_PARAM_ID: i32 = 105;
-// TODO: make sure default level is correct
+
+// TODO: make sure these defaults are correct
 const DEFAULT_LEVEL: Option<i32> = Some(200);
 const DEFAULT_SENSOR: Option<i32> = Some(0);
+
+/// Maximum duration value (in minutes) we can process
 const MAX_ALLOWED_DURATION: u32 = 10000;
 
 /// Durations (in minutes) for which the maximum precipitation intensity sum is computed if no duration
@@ -71,13 +75,13 @@ struct RainfallDatum {
 // TODO: this is an adapted version of get_patchwork with two more WHERE conditions.
 // Are we fine having separate "patchwork" queries for specific tasks?
 async fn fetch_rain_data(
-    timeseries: Vec<(i64, DateTime<Utc>, DateTime<Utc>)>,
+    patches: Vec<Patch>,
     conn: &PooledPgConn<'_>,
-) -> Result<Vec<RainfallDatum>, tokio_postgres::Error> {
+) -> Result<Vec<RainfallDatum>, Error> {
     // TODO: are these timeseries ordered by fromtime?
-    let mut futures = timeseries
+    let mut futures = patches
         .iter()
-        .map(|(tsid, from, to)| async move {
+        .map(|patch| async move {
             conn.query(
                 "SELECT obstime, corrected, \
                  FROM legacy.data \
@@ -85,14 +89,13 @@ async fn fetch_rain_data(
                    AND corrected IS NOT NULL \
                    AND quality_code != 7 \
                    AND obstime BETWEEN $2 AND $3",
-                &[&tsid, &from, &to],
+                &[&patch.tsid, &patch.from, &patch.to],
             )
             .await
         })
         .collect::<FuturesOrdered<_>>();
 
     let mut data = Vec::new();
-
     while let Some(res) = futures.next().await {
         let rows = res?;
 
@@ -154,16 +157,6 @@ pub async fn idf_event_handler(
     State(tables): State<PatchworkTimeseriesTables>,
     Query(params): Query<IdfEventParams>,
 ) -> Result<Json<IdfEventResp>, (StatusCode, String)> {
-    // We allow any provided duration that is less or equal to `MAX_ALLOWED_DURATION`
-    let durations: Option<Vec<u32>> = params.durations.map(|durations| {
-        durations
-            .into_iter()
-            .filter(|d| *d <= MAX_ALLOWED_DURATION)
-            .collect()
-    });
-
-    let durations = durations.as_deref().unwrap_or(DEFAULT_DURATIONS);
-
     let label = PatchworkLabel::new(
         station_id,
         PRECIPITATION_PARAM_ID,
@@ -171,7 +164,7 @@ pub async fn idf_event_handler(
         DEFAULT_SENSOR,
     );
 
-    let timeseries = get_applicable_timeseries(
+    let patches = patchwork::get_applicable_timeseries(
         params.fromtime,
         params.totime,
         label,
@@ -185,7 +178,7 @@ pub async fn idf_event_handler(
     // TODO: this should be handled by auth
     let conn = pools.open.get().await.map_err(error::internal_error)?;
 
-    let data = fetch_rain_data(timeseries, &conn)
+    let data = fetch_rain_data(patches, &conn)
         .await
         .map_err(internal_error)?;
 
@@ -196,6 +189,15 @@ pub async fn idf_event_handler(
         ));
     }
 
+    // We allow any provided duration that is less or equal to `MAX_ALLOWED_DURATION`
+    let inputs: Option<Vec<u32>> = params.durations.map(|values| {
+        values
+            .into_iter()
+            .filter(|val| *val <= MAX_ALLOWED_DURATION)
+            .collect()
+    });
+
+    let durations = inputs.as_deref().unwrap_or(DEFAULT_DURATIONS);
     let values = collect_idf_events(durations, data);
 
     Ok(Json(IdfEventResp {

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -4,16 +4,24 @@ use axum::{
     Json,
 };
 use chrono::{DateTime, TimeDelta, Utc};
+use futures::{stream::FuturesOrdered, StreamExt};
 use serde::{Deserialize, Serialize};
-use util::PooledPgConn;
+use util::{DbPools, PooledPgConn};
 
-use crate::{error, PgConnectionPool};
+use crate::{
+    error::{self, internal_error, not_found_error},
+    patchwork::{get_applicable_timeseries, PatchworkLabel, PatchworkTimeseriesTables},
+};
 
 use super::idf_station::IdfUnit;
 
+const PRECIPITATION_PARAM_ID: i32 = 105;
+// TODO: make sure default level is correct
+const DEFAULT_LEVEL: Option<i32> = Some(200);
+const DEFAULT_SENSOR: Option<i32> = Some(0);
 const MAX_ALLOWED_DURATION: u32 = 10000;
 
-/// Durations for which the maximum precipitation intensity sum is computed if no duration
+/// Durations (in minutes) for which the maximum precipitation intensity sum is computed if no duration
 /// value is provided in the query parameters
 const DEFAULT_DURATIONS: &[u32] = &[
     1, 2, 3, 5, 10, 15, 20, 30, 45, 60, 90, 120, 180, 360, 720, 1440,
@@ -38,8 +46,8 @@ pub struct IdfEventResp {
     values: Vec<IdfEvent>,
 }
 
-// IDF event is defined as the maximum sum of precipitation intensities
-// over windows of a given duration
+/// An IDF event is defined as the maximum sum of precipitation intensities
+/// over windows of a given duration
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct IdfEvent {
@@ -55,49 +63,51 @@ struct IdfEvent {
 
 // Struct used to deserialize rows fetched from LARD
 struct RainfallDatum {
-    obstime: DateTime<Utc>,
-    obsvalue: f64,
+    timestamp: DateTime<Utc>,
+    value: f64,
 }
 
-/// Fetches all PT1M rainfall observations (param_id = 105) for the given station ID and time range
-// TODO: Switch to hourly automatic data, instead of minute data, because old manual data was way
-// too approximate. Use typeid 501 to select only hourly?
+/// Fetches all rainfall observations given the vector of timeseries patches
+// TODO: this is an adapted version of get_patchwork with two more WHERE conditions.
+// Are we fine having separate "patchwork" queries for specific tasks?
 async fn fetch_rain_data(
-    station_id: i32,
-    fromtime: DateTime<Utc>,
-    totime: DateTime<Utc>,
+    timeseries: Vec<(i64, DateTime<Utc>, DateTime<Utc>)>,
     conn: &PooledPgConn<'_>,
 ) -> Result<Vec<RainfallDatum>, tokio_postgres::Error> {
-    // TODO: make sure default level is correct
-    // TODO: in ODA this uses the met.no/filter label, so we probably need to implement that one
-    // instead?
-    // TODO: should obstime include totime timestamp?
-    let query = "SELECT obstime, corrected FROM legacy.data \
-                 JOIN labels.met ON (timeseries) \
-                 WHERE station_id = $1 \
-                   AND param_id = 105 \
-                   AND sensor = 0 \
-                   AND level = 200 \
+    // TODO: are these timeseries ordered by fromtime?
+    let mut futures = timeseries
+        .iter()
+        .map(|(tsid, from, to)| async move {
+            conn.query(
+                "SELECT obstime, corrected, \
+                 FROM legacy.data \
+                 WHERE timeseries = $1 \
                    AND corrected IS NOT NULL \
-                   AND quality_code != 7
-                   AND obstime >= $2 AND obstime < $3 \
-                 ORDER BY obstime";
-
-    let rows = conn
-        .query(query, &[&station_id, &fromtime, &totime])
-        .await?;
-
-    Ok(rows
-        .into_iter()
-        .map(|row| RainfallDatum {
-            obstime: row.get(0),
-            obsvalue: row.get(1),
+                   AND quality_code != 7 \
+                   AND obstime BETWEEN $2 AND $3",
+                &[&tsid, &from, &to],
+            )
+            .await
         })
-        .collect())
+        .collect::<FuturesOrdered<_>>();
+
+    let mut data = Vec::new();
+
+    while let Some(res) = futures.next().await {
+        let rows = res?;
+
+        for row in rows {
+            data.push(RainfallDatum {
+                timestamp: row.get(0),
+                value: row.get(1),
+            });
+        }
+    }
+
+    Ok(data)
 }
 
-// Computes the IDF event for the input `duration` using the
-// precipitation `data` fetched from LARD.
+/// Computes the IDF event for the input `duration` using the precipitation `data` fetched from LARD.
 fn calculate_idf_event(duration: u32, data: &[RainfallDatum]) -> IdfEvent {
     let mut maximum = IdfEvent {
         duration,
@@ -108,18 +118,20 @@ fn calculate_idf_event(duration: u32, data: &[RainfallDatum]) -> IdfEvent {
 
     // NOTE: unfortunately we can't use a window iterator because the data is not regular
     for (i, val) in data.iter().enumerate() {
-        let start_time = val.obstime;
+        let start_time = val.timestamp;
         let cutoff_time = start_time + TimeDelta::minutes(duration as i64);
 
-        // Manually compute the sum of intensities making sure all considered observations fall
-        // inside the given cutoff_time
-        let (window_sum, end_time) = data[i..]
+        // Manually compute the sum of intensities using only observations that fall
+        // before the given cutoff time
+        let (window_intensity, end_time) = data[i..]
             .iter()
-            .take_while(|v| v.obstime < cutoff_time)
-            .fold((0.0, val.obstime), |acc, v| (acc.0 + v.obsvalue, v.obstime));
+            .take_while(|obs| obs.timestamp < cutoff_time)
+            .fold((0.0, val.timestamp), |acc, obs| {
+                (acc.0 + obs.value, obs.timestamp)
+            });
 
-        if window_sum > maximum.intensity {
-            maximum.intensity = window_sum;
+        if window_intensity > maximum.intensity {
+            maximum.intensity = window_intensity;
             maximum.fromtime = start_time;
             maximum.totime = end_time;
         }
@@ -138,10 +150,11 @@ fn collect_idf_events(durations: &[u32], data: Vec<RainfallDatum>) -> Vec<IdfEve
 
 pub async fn idf_event_handler(
     Path(station_id): Path<i32>,
-    State(pool): State<PgConnectionPool>,
+    State(pools): State<DbPools>,
+    State(tables): State<PatchworkTimeseriesTables>,
     Query(params): Query<IdfEventParams>,
 ) -> Result<Json<IdfEventResp>, (StatusCode, String)> {
-    // We allow any provided duration that is less than `MAX_ALLOWED_DURATION`
+    // We allow any provided duration that is less or equal to `MAX_ALLOWED_DURATION`
     let durations: Option<Vec<u32>> = params.durations.map(|durations| {
         durations
             .into_iter()
@@ -149,16 +162,32 @@ pub async fn idf_event_handler(
             .collect()
     });
 
-    // TODO: is there a way to combine these `durations` preprocessing?
-    let durations = match durations {
-        Some(ref d) => d,
-        None => DEFAULT_DURATIONS,
-    };
+    let durations = durations.as_deref().unwrap_or(DEFAULT_DURATIONS);
 
-    let conn = pool.get().await.map_err(error::internal_error)?;
-    let data = fetch_rain_data(station_id, params.fromtime, params.totime, &conn)
+    let label = PatchworkLabel::new(
+        station_id,
+        PRECIPITATION_PARAM_ID,
+        DEFAULT_LEVEL,
+        DEFAULT_SENSOR,
+    );
+
+    let timeseries = get_applicable_timeseries(
+        params.fromtime,
+        params.totime,
+        label,
+        tables.open,
+        Some(tables.restricted),
+    )
+    .map_err(not_found_error)?
+    // TODO: this should not return an option?
+    .unwrap();
+
+    // TODO: this should be handled by auth
+    let conn = pools.open.get().await.map_err(error::internal_error)?;
+
+    let data = fetch_rain_data(timeseries, &conn)
         .await
-        .map_err(error::internal_error)?;
+        .map_err(internal_error)?;
 
     if data.is_empty() {
         return Err((
@@ -182,12 +211,12 @@ mod tests {
     use chrono::TimeZone;
 
     impl RainfallDatum {
-        fn new(year: i32, month: u32, day: u32, hour: u32, min: u32, obsvalue: f64) -> Self {
+        fn new(year: i32, month: u32, day: u32, hour: u32, min: u32, value: f64) -> Self {
             Self {
-                obstime: Utc
+                timestamp: Utc
                     .with_ymd_and_hms(year, month, day, hour, min, 0)
                     .unwrap(),
-                obsvalue,
+                value,
             }
         }
     }

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -8,7 +8,7 @@ use axum::{
 use chrono::{DateTime, TimeDelta, Utc};
 use futures::{stream::FuturesOrdered, StreamExt};
 use serde::{Deserialize, Serialize};
-use util::{DbPools, PooledPgConn};
+use util::{deserialize::optional_comma_separated, DbPools, PooledPgConn};
 
 use crate::{
     error::{internal_error, not_found_error, Error},
@@ -38,6 +38,7 @@ const DEFAULT_DURATIONS: &[u32] = &[
 pub struct IdfEventParams {
     #[serde(default)]
     unit: IdfUnit,
+    #[serde(deserialize_with = "optional_comma_separated")]
     durations: Option<Vec<u32>>,
     fromtime: DateTime<Utc>,
     totime: DateTime<Utc>,

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -261,18 +261,32 @@ fn is_idf_event_timeseries(label: &PatchworkLabel) -> bool {
 }
 
 pub async fn idf_event_availability_handler(
-    State(patchwork_tables): State<PatchworkTables>,
+    State(tables): State<PatchworkTables>,
+    Extension(roles): Extension<Option<Vec<i32>>>,
 ) -> Result<Json<IdfEventAvailability>, (StatusCode, String)> {
-    // TODO: need to implement this also for restricted?
-    let ot = patchwork_tables.open.read().map_err(internal_error)?;
+    let ot = tables.open.read().map_err(internal_error)?;
 
     // TODO: not sure how performant this is, maybe faster to check the DB?
     // Or we need a different datastructure
-    let stations = ot
+    // TODO: add timeranges for the different stations ?
+    let mut stations: Vec<_> = ot
         .keys()
         .filter(|label| is_idf_event_timeseries(label))
         .map(|label| label.station_id)
         .collect();
+
+    if let Some(roles) = roles {
+        let rt = tables.restricted.read().map_err(internal_error)?;
+
+        stations.extend(
+            rt.iter()
+                .filter(|(label, _)| is_idf_event_timeseries(label))
+                // All fill should have the same permit id (since restrictions are applied to whole
+                // stations or single params)
+                .filter(|(_, fills)| fills.iter().any(|fill| roles.contains(&fill.permit)))
+                .map(|(label, _)| label.station_id),
+        );
+    }
 
     Ok(Json(IdfEventAvailability { stations }))
 }

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -248,7 +248,7 @@ pub async fn idf_event_handler(
 
 /// Response struct returned by the availability endpoint
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct IdfEventAvailability {
+pub struct IdfEventAvailabilityResp {
     /// List of stations for which IDF calculation is possible
     pub stations: Vec<i32>,
 }
@@ -262,7 +262,7 @@ fn is_idf_event_timeseries(label: &PatchworkLabel) -> bool {
 pub async fn idf_event_availability_handler(
     State(tables): State<PatchworkTables>,
     Extension(roles): Extension<Option<Vec<i32>>>,
-) -> Result<Json<IdfEventAvailability>, (StatusCode, String)> {
+) -> Result<Json<IdfEventAvailabilityResp>, (StatusCode, String)> {
     let ot = tables.open.read().map_err(internal_error)?;
 
     // TODO: not sure how performant this is, maybe we need a different data structure?
@@ -279,14 +279,14 @@ pub async fn idf_event_availability_handler(
         stations.extend(
             rt.iter()
                 .filter(|(label, _)| is_idf_event_timeseries(label))
-                // NOTE: All fill should have the same permit id (since restrictions are applied to whole
-                // stations or single params)
+                // NOTE: All fills should have the same permit id since restrictions are applied to whole
+                // stations or single params
                 .filter(|(_, fills)| roles.contains(&fills[0].permit))
                 .map(|(label, _)| label.station_id),
         );
     }
 
-    Ok(Json(IdfEventAvailability { stations }))
+    Ok(Json(IdfEventAvailabilityResp { stations }))
 }
 
 #[cfg(test)]

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -107,10 +107,6 @@ async fn fetch_rain_data(
         return Ok(None);
     }
 
-    // Patches are not sorted, but we need data ordered by timestamp
-    // TODO: need to add a test for this
-    patches.sort_by_key(|fill| fill.from);
-
     let conn = pool.get().await?;
 
     // The IDF event calculation requires

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, RwLock};
+
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -6,11 +8,11 @@ use axum::{
 use chrono::{DateTime, TimeDelta, Utc};
 use futures::{stream::FuturesOrdered, StreamExt};
 use serde::{Deserialize, Serialize};
-use util::{deserialize::optional_comma_separated, DbPools, PooledPgConn};
+use util::{deserialize::optional_comma_separated, DbPools, PgPool};
 
 use crate::{
     error::{internal_error, Error},
-    patchwork::{self, Patch, PatchworkLabel, PatchworkTables},
+    patchwork::{self, PatchworkLabel, PatchworkTables, PatchworkTimeseriesTable},
     reports::idf_station::mm_to_lsha,
 };
 
@@ -90,17 +92,31 @@ struct RainfallDatum {
     value: f64,
 }
 
-/// Fetches rainfall observations given the vector of timeseries patches
+// Fetches rainfall observations given the vector of timeseries patches
 async fn fetch_rain_data(
-    patches: Vec<Patch>,
-    conn: &PooledPgConn<'_>,
-) -> Result<Vec<RainfallDatum>, Error> {
+    label: PatchworkLabel,
+    params: &IdfEventParams,
+    roles: &[i32],
+    pool: PgPool,
+    table: Arc<RwLock<PatchworkTimeseriesTable>>,
+) -> Result<Option<Vec<RainfallDatum>>, Error> {
+    let mut patches =
+        patchwork::get_applicable_timeseries(params.fromtime, params.totime, label, table)?;
+
+    if patches.is_empty() {
+        return Ok(None);
+    }
+
+    // Patches are not sorted, but we need data ordered by timestamp
+    // TODO: need to add a test for this
+    patches.sort_by_key(|fill| fill.from);
+
+    let conn = pool.get().await?;
+
     // The IDF event calculation requires
     // - data that has been QCed (lines with `corrected`)
     // - non erroneous data (quality_code != 7)
-    // TODO: BETWEEN is wrong with patchwork because we would double count the same obstime twice,
-    // but then the last obstime is not included
-    let stmt = conn
+    let statement = conn
         .prepare(
             "SELECT obstime, corrected \
                 FROM legacy.data \
@@ -114,11 +130,11 @@ async fn fetch_rain_data(
         )
         .await?;
 
-    // TODO: are these patches ordered by fromtime?
     let mut futures = patches
         .iter()
+        .filter(|patch| patch.permit_id == 1 || roles.contains(&patch.permit_id))
         .map(|patch| async {
-            conn.query(&stmt, &[&patch.tsid, &patch.from, &patch.to])
+            conn.query(&statement, &[&patch.tsid, &patch.from, &patch.to])
                 .await
         })
         .collect::<FuturesOrdered<_>>();
@@ -135,7 +151,7 @@ async fn fetch_rain_data(
         }
     }
 
-    Ok(data)
+    Ok(Some(data))
 }
 
 /// Computes the IDF event for the input `duration` using the precipitation `data` fetched from LARD.
@@ -190,44 +206,39 @@ pub async fn idf_event_handler(
     Query(params): Query<IdfEventParams>,
     Extension(roles): Extension<Option<Vec<i32>>>,
 ) -> Result<Json<IdfEventResp>, (StatusCode, String)> {
-    let idf_event_label = PatchworkLabel::new(
+    let idf_label = PatchworkLabel::new(
         station_id,
         PRECIPITATION_PARAM_ID,
         DEFAULT_LEVEL,
         DEFAULT_SENSOR,
     );
 
-    let (patches, pool) = patchwork::get_patches(
-        params.fromtime,
-        params.totime,
-        idf_event_label,
-        tables,
-        pools,
-        roles,
-    )
-    .await
-    .map_err(internal_error)?;
+    let data = {
+        let open = fetch_rain_data(idf_label, &params, &[], pools.open, tables.open)
+            .await
+            .map_err(internal_error)?;
 
-    if patches.is_empty() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            "No applicable timeseries in the given time period".to_string(),
-        ));
-    };
-
-    // TODO: this should be handled by auth
-    let conn = pool.get().await.map_err(internal_error)?;
-
-    let data = fetch_rain_data(patches, &conn)
-        .await
-        .map_err(internal_error)?;
-
-    if data.is_empty() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            format!("No precipitation data found for station {station_id}"),
-        ));
+        match open {
+            Some(data) => Some(data),
+            None => match roles {
+                Some(r) => {
+                    fetch_rain_data(idf_label, &params, &r, pools.restricted, tables.restricted)
+                        .await
+                        .map_err(internal_error)?
+                }
+                None => {
+                    return Err((
+                        StatusCode::NOT_FOUND,
+                        "No applicable timeseries in the given time period".to_string(),
+                    ))
+                }
+            },
+        }
     }
+    .ok_or((
+        StatusCode::NOT_FOUND,
+        format!("No precipitation data found for station {station_id}"),
+    ))?;
 
     // We allow any provided duration that is less or equal to `MAX_ALLOWED_DURATION`
     let inputs: Option<Vec<u32>> = params.durations.map(|values| {

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -100,8 +100,8 @@ async fn fetch_rain_data(
     pool: PgPool,
     table: Arc<RwLock<PatchworkTimeseriesTable>>,
 ) -> Result<Option<Vec<RainfallDatum>>, Error> {
-    let mut patches =
-        patchwork::get_applicable_timeseries(params.fromtime, params.totime, label, table)?;
+    let patches =
+        patchwork::get_applicable_timeseries(params.fromtime, params.totime, label, roles, table)?;
 
     if patches.is_empty() {
         return Ok(None);
@@ -112,7 +112,7 @@ async fn fetch_rain_data(
     // The IDF event calculation requires
     // - data that has been QCed (lines with `corrected`)
     // - non erroneous data (quality_code != 7)
-    let statement = conn
+    let query = conn
         .prepare(
             "SELECT obstime, corrected \
                 FROM legacy.data \
@@ -128,9 +128,8 @@ async fn fetch_rain_data(
 
     let mut futures = patches
         .iter()
-        .filter(|patch| patch.permit_id == 1 || roles.contains(&patch.permit_id))
         .map(|patch| async {
-            conn.query(&statement, &[&patch.tsid, &patch.from, &patch.to])
+            conn.query(&query, &[&patch.tsid, &patch.from, &patch.to])
                 .await
         })
         .collect::<FuturesOrdered<_>>();

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -10,7 +10,7 @@ use util::{deserialize::optional_comma_separated, DbPools, PooledPgConn};
 
 use crate::{
     error::{internal_error, Error},
-    patchwork::{self, Patch, PatchworkLabel, PatchworkTimeseriesTables},
+    patchwork::{self, Patch, PatchworkLabel, PatchworkTables},
     reports::idf_station::mm_to_lsha,
 };
 
@@ -28,7 +28,7 @@ const MAX_ALLOWED_DURATION: u32 = 10000;
 
 /// Durations (in minutes) for which the maximum precipitation intensity sum is computed if no duration
 /// value is provided in the query parameters
-const DEFAULT_DURATIONS: &[u32] = &[
+pub const DEFAULT_DURATIONS: &[u32] = &[
     1, 2, 3, 5, 10, 15, 20, 30, 45, 60, 90, 120, 180, 360, 720, 1440,
 ];
 
@@ -37,7 +37,7 @@ const DEFAULT_DURATIONS: &[u32] = &[
 pub struct IdfEventParams {
     #[serde(default)]
     unit: IdfUnit,
-    #[serde(deserialize_with = "optional_comma_separated")]
+    #[serde(default, deserialize_with = "optional_comma_separated")]
     durations: Option<Vec<u32>>,
     fromtime: DateTime<Utc>,
     totime: DateTime<Utc>,
@@ -47,16 +47,16 @@ pub struct IdfEventParams {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdfEventResp {
-    station_id: i32,
-    unit: IdfUnit,
-    values: Vec<IdfEvent>,
+    pub station_id: i32,
+    pub unit: IdfUnit,
+    pub values: Vec<IdfEvent>,
 }
 
 /// An IDF event is defined as the maximum sum of precipitation intensities
 /// over windows of a given duration
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct IdfEvent {
+pub struct IdfEvent {
     /// Sum of rainfall intensities over a given duration window
     intensity: f64,
     /// The maximum allowed time delta between first and last observations in a window
@@ -67,7 +67,24 @@ struct IdfEvent {
     totime: DateTime<Utc>,
 }
 
+impl IdfEvent {
+    pub fn new(
+        intensity: f64,
+        duration: u32,
+        fromtime: DateTime<Utc>,
+        totime: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            intensity,
+            duration,
+            fromtime,
+            totime,
+        }
+    }
+}
+
 // Struct used to deserialize rows fetched from LARD
+#[derive(Debug)]
 struct RainfallDatum {
     timestamp: DateTime<Utc>,
     value: f64,
@@ -81,6 +98,8 @@ async fn fetch_rain_data(
     // The IDF event calculation requires
     // - data that has been QCed (lines with `corrected`)
     // - non erroneous data (quality_code != 7)
+    // TODO: BETWEEN is wrong with patchwork because we would double count the same obstime twice,
+    // but then the last obstime is not included
     let stmt = conn
         .prepare(
             "SELECT obstime, corrected \
@@ -89,7 +108,8 @@ async fn fetch_rain_data(
                     AND corrected IS NOT NULL \
                     AND corrected > -30000.0 \
                     AND quality_code != 7 \
-                    AND obstime BETWEEN $2 AND $3
+                    AND obstime >= $2 \
+                    AND obstime < $3 \
                 ORDER BY obstime",
         )
         .await?;
@@ -137,7 +157,7 @@ fn calculate_idf_event(duration: u32, data: &[RainfallDatum], unit: IdfUnit) -> 
         let (window_intensity, end_time) = data[i..]
             .iter()
             .take_while(|obs| obs.timestamp < cutoff_time)
-            .fold((0.0, val.timestamp), |acc, obs| {
+            .fold((0.0, start_time), |acc, obs| {
                 (acc.0 + obs.value, obs.timestamp)
             });
 
@@ -166,7 +186,7 @@ fn collect_idf_events(durations: &[u32], data: Vec<RainfallDatum>, unit: IdfUnit
 pub async fn idf_event_handler(
     Path(station_id): Path<i32>,
     State(pools): State<DbPools>,
-    State(tables): State<PatchworkTimeseriesTables>,
+    State(tables): State<PatchworkTables>,
     Query(params): Query<IdfEventParams>,
 ) -> Result<Json<IdfEventResp>, (StatusCode, String)> {
     let idf_event_label = PatchworkLabel::new(
@@ -238,7 +258,7 @@ fn is_idf_event_timeseries(label: &PatchworkLabel) -> bool {
 }
 
 pub async fn idf_event_availability_handler(
-    State(patchwork_tables): State<PatchworkTimeseriesTables>,
+    State(patchwork_tables): State<PatchworkTables>,
 ) -> Result<Json<IdfEventAvailability>, (StatusCode, String)> {
     // TODO: need to implement this also for restricted?
     let ot = patchwork_tables.open.read().map_err(internal_error)?;

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -248,10 +248,26 @@ pub async fn idf_event_handler(
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdfEventAvailable {
-    station_id: i32,
+    pub station_id: i32,
     permit: i32,
     from: DateTime<Utc>,
     to: Option<DateTime<Utc>>,
+}
+
+impl IdfEventAvailable {
+    pub fn new(
+        station_id: i32,
+        permit: i32,
+        from: DateTime<Utc>,
+        to: Option<DateTime<Utc>>,
+    ) -> Self {
+        Self {
+            station_id,
+            permit,
+            from,
+            to,
+        }
+    }
 }
 
 /// Response struct returned by the availability endpoint

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -247,16 +247,18 @@ pub async fn idf_event_handler(
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct IdfAvailable {
+pub struct IdfEventAvailable {
     station_id: i32,
     permit: i32,
+    from: DateTime<Utc>,
+    to: Option<DateTime<Utc>>,
 }
 
 /// Response struct returned by the availability endpoint
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdfEventAvailabilityResp {
     /// List of stations for which IDF calculation is possible
-    pub stations: Vec<IdfAvailable>,
+    pub stations: Vec<IdfEventAvailable>,
 }
 
 fn is_idf_event_timeseries(label: &PatchworkLabel) -> bool {
@@ -272,13 +274,14 @@ pub async fn idf_event_availability_handler(
     let ot = tables.open.read().map_err(internal_error)?;
 
     // TODO: not sure how performant this is, maybe we need a different data structure?
-    // TODO: add timeranges and permits for the different stations?
     let mut stations: Vec<_> = ot
         .iter()
         .filter(|(label, _)| is_idf_event_timeseries(label))
-        .map(|(label, fills)| IdfAvailable {
+        .map(|(label, fills)| IdfEventAvailable {
             station_id: label.station_id,
             permit: fills[0].permit,
+            from: fills[0].from,
+            to: fills.iter().last().unwrap().to,
         })
         .collect();
 
@@ -291,13 +294,16 @@ pub async fn idf_event_availability_handler(
                 // NOTE: All fills should have the same permit id since restrictions are applied to whole
                 // stations or single params
                 .filter(|(_, fills)| roles.contains(&fills[0].permit))
-                .map(|(label, fills)| IdfAvailable {
+                .map(|(label, fills)| IdfEventAvailable {
                     station_id: label.station_id,
                     permit: fills[0].permit,
+                    from: fills[0].from,
+                    to: fills.iter().last().unwrap().to,
                 }),
         );
     }
 
+    // TODO: should this be sorted by station_id?
     Ok(Json(IdfEventAvailabilityResp { stations }))
 }
 

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -281,9 +281,9 @@ pub async fn idf_event_availability_handler(
         stations.extend(
             rt.iter()
                 .filter(|(label, _)| is_idf_event_timeseries(label))
-                // All fill should have the same permit id (since restrictions are applied to whole
+                // NOTE: All fill should have the same permit id (since restrictions are applied to whole
                 // stations or single params)
-                .filter(|(_, fills)| fills.iter().any(|fill| roles.contains(&fill.permit)))
+                .filter(|(_, fills)| roles.contains(&fills[0].permit))
                 .map(|(label, _)| label.station_id),
         );
     }

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -1,0 +1,277 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::{DateTime, TimeDelta, Utc};
+use serde::{Deserialize, Serialize};
+use util::PooledPgConn;
+
+use crate::{error, PgConnectionPool};
+
+use super::idf_station::IdfUnit;
+
+const MAX_ALLOWED_DURATION: u32 = 10000;
+
+/// Durations for which the maximum precipitation intensity sum is computed if no duration
+/// value is provided in the query parameters
+const DEFAULT_DURATIONS: &[u32] = &[
+    1, 2, 3, 5, 10, 15, 20, 30, 45, 60, 90, 120, 180, 360, 720, 1440,
+];
+
+/// Query parameters struct for the idf/event/{station_id} endpoint
+#[derive(Serialize, Deserialize)]
+pub struct IdfEventParams {
+    #[serde(default)]
+    unit: IdfUnit,
+    durations: Option<Vec<u32>>,
+    fromtime: DateTime<Utc>,
+    totime: DateTime<Utc>,
+}
+
+/// Response struct returned by the idf/event/{station_id} endpoint
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IdfEventResp {
+    station_id: i32,
+    unit: IdfUnit,
+    values: Vec<IdfEvent>,
+}
+
+// IDF event is defined as the maximum sum of precipitation intensities
+// over windows of a given duration
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IdfEvent {
+    /// Sum of rainfall intensities over a given duration window
+    intensity: f64,
+    /// The maximum allowed time delta between first and last observations in a window
+    duration: u32,
+    /// Timestamp of the first observation considered in the sum
+    fromtime: DateTime<Utc>,
+    /// Timestamp of the last observation considered in the sum
+    totime: DateTime<Utc>,
+}
+
+// Struct used to deserialize rows fetched from LARD
+struct RainfallDatum {
+    obstime: DateTime<Utc>,
+    obsvalue: f64,
+}
+
+/// Fetches all PT1M rainfall observations (param_id = 105) for the given station ID and time range
+// TODO: Switch to hourly automatic data, instead of minute data, because old manual data was way
+// too approximate. Use typeid 501 to select only hourly?
+async fn fetch_rain_data(
+    station_id: i32,
+    fromtime: DateTime<Utc>,
+    totime: DateTime<Utc>,
+    conn: &PooledPgConn<'_>,
+) -> Result<Vec<RainfallDatum>, tokio_postgres::Error> {
+    // TODO: make sure default level is correct
+    // TODO: in ODA this uses the met.no/filter label, so we probably need to implement that one
+    // instead?
+    // TODO: should obstime include totime timestamp?
+    let query = "SELECT obstime, corrected FROM legacy.data \
+                 JOIN labels.met ON (timeseries) \
+                 WHERE station_id = $1 \
+                   AND param_id = 105 \
+                   AND sensor = 0 \
+                   AND level = 200 \
+                   AND corrected IS NOT NULL \
+                   AND quality_code != 7
+                   AND obstime >= $2 AND obstime < $3 \
+                 ORDER BY obstime";
+
+    let rows = conn
+        .query(query, &[&station_id, &fromtime, &totime])
+        .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| RainfallDatum {
+            obstime: row.get(0),
+            obsvalue: row.get(1),
+        })
+        .collect())
+}
+
+// Computes the IDF event for the input `duration` using the
+// precipitation `data` fetched from LARD.
+fn calculate_idf_event(duration: u32, data: &[RainfallDatum]) -> IdfEvent {
+    let mut maximum = IdfEvent {
+        duration,
+        fromtime: DateTime::default(),
+        totime: DateTime::default(),
+        intensity: f64::NEG_INFINITY,
+    };
+
+    // NOTE: unfortunately we can't use a window iterator because the data is not regular
+    for (i, val) in data.iter().enumerate() {
+        let start_time = val.obstime;
+        let cutoff_time = start_time + TimeDelta::minutes(duration as i64);
+
+        // Manually compute the sum of intensities making sure all considered observations fall
+        // inside the given cutoff_time
+        let (window_sum, end_time) = data[i..]
+            .iter()
+            .take_while(|v| v.obstime < cutoff_time)
+            .fold((0.0, val.obstime), |acc, v| (acc.0 + v.obsvalue, v.obstime));
+
+        if window_sum > maximum.intensity {
+            maximum.intensity = window_sum;
+            maximum.fromtime = start_time;
+            maximum.totime = end_time;
+        }
+    }
+
+    maximum
+}
+
+// TODO: should spawn in separate thread and use par_iter instead of into_iter?
+fn collect_idf_events(durations: &[u32], data: Vec<RainfallDatum>) -> Vec<IdfEvent> {
+    durations
+        .iter()
+        .map(|&duration| calculate_idf_event(duration, &data))
+        .collect()
+}
+
+pub async fn idf_event_handler(
+    Path(station_id): Path<i32>,
+    State(pool): State<PgConnectionPool>,
+    Query(params): Query<IdfEventParams>,
+) -> Result<Json<IdfEventResp>, (StatusCode, String)> {
+    // We allow any provided duration that is less than `MAX_ALLOWED_DURATION`
+    let durations: Option<Vec<u32>> = params.durations.map(|durations| {
+        durations
+            .into_iter()
+            .filter(|d| *d <= MAX_ALLOWED_DURATION)
+            .collect()
+    });
+
+    // TODO: is there a way to combine these `durations` preprocessing?
+    let durations = match durations {
+        Some(ref d) => d,
+        None => DEFAULT_DURATIONS,
+    };
+
+    let conn = pool.get().await.map_err(error::internal_error)?;
+    let data = fetch_rain_data(station_id, params.fromtime, params.totime, &conn)
+        .await
+        .map_err(error::internal_error)?;
+
+    if data.is_empty() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("No precipitation data found for station {station_id}"),
+        ));
+    }
+
+    let values = collect_idf_events(durations, data);
+
+    Ok(Json(IdfEventResp {
+        station_id,
+        unit: params.unit,
+        values,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    impl RainfallDatum {
+        fn new(year: i32, month: u32, day: u32, hour: u32, min: u32, obsvalue: f64) -> Self {
+            Self {
+                obstime: Utc
+                    .with_ymd_and_hms(year, month, day, hour, min, 0)
+                    .unwrap(),
+                obsvalue,
+            }
+        }
+    }
+
+    #[test]
+    fn test_oda_output_match() {
+        let durations = [1, 2, 5, 7, 10, 15];
+
+        let data = vec![
+            RainfallDatum::new(2000, 1, 1, 0, 0, 1.),
+            RainfallDatum::new(2000, 1, 1, 0, 10, 2.),
+            RainfallDatum::new(2000, 1, 1, 0, 11, 3.),
+            RainfallDatum::new(2000, 1, 1, 0, 12, 4.),
+            RainfallDatum::new(2000, 1, 1, 0, 13, 5.),
+            RainfallDatum::new(2000, 1, 1, 0, 14, 6.),
+            RainfallDatum::new(2000, 1, 1, 0, 15, 7.),
+            RainfallDatum::new(2000, 1, 1, 0, 16, 7.),
+            RainfallDatum::new(2000, 1, 1, 0, 17, 14.),
+            RainfallDatum::new(2000, 1, 1, 0, 18, 7.),
+            RainfallDatum::new(2000, 1, 1, 0, 19, 7.),
+            RainfallDatum::new(2000, 1, 1, 0, 20, 7.),
+            RainfallDatum::new(2000, 1, 1, 0, 21, 7.),
+            RainfallDatum::new(2000, 1, 1, 0, 22, 7.),
+            RainfallDatum::new(2000, 1, 1, 0, 23, 7.),
+            RainfallDatum::new(2000, 1, 1, 0, 24, 7.),
+            RainfallDatum::new(2000, 1, 1, 0, 25, 7.),
+            RainfallDatum::new(2000, 1, 1, 0, 30, 8.),
+            RainfallDatum::new(2000, 1, 1, 0, 40, 9.),
+            RainfallDatum::new(2000, 1, 1, 0, 50, 8.),
+            RainfallDatum::new(2000, 1, 1, 0, 51, 7.),
+            RainfallDatum::new(2000, 1, 1, 0, 52, 6.),
+            RainfallDatum::new(2000, 1, 1, 0, 53, 5.),
+            RainfallDatum::new(2000, 1, 1, 0, 54, 4.),
+            RainfallDatum::new(2000, 1, 1, 0, 55, 3.),
+            RainfallDatum::new(2000, 1, 1, 1, 5, 3.),
+            RainfallDatum::new(2000, 1, 1, 1, 15, 23.),
+            RainfallDatum::new(2000, 1, 2, 0, 5, 14.),
+        ];
+
+        let expected = vec![
+            IdfEvent {
+                intensity: 23.0,
+                duration: 1,
+                fromtime: Utc.with_ymd_and_hms(2000, 1, 1, 1, 15, 0).unwrap(),
+                totime: Utc.with_ymd_and_hms(2000, 1, 1, 1, 15, 0).unwrap(),
+            },
+            IdfEvent {
+                intensity: 23.0,
+                duration: 2,
+                fromtime: Utc.with_ymd_and_hms(2000, 1, 1, 1, 15, 0).unwrap(),
+                totime: Utc.with_ymd_and_hms(2000, 1, 1, 1, 15, 0).unwrap(),
+            },
+            IdfEvent {
+                intensity: 42.0,
+                duration: 5,
+                fromtime: Utc.with_ymd_and_hms(2000, 1, 1, 0, 15, 0).unwrap(),
+                totime: Utc.with_ymd_and_hms(2000, 1, 1, 0, 19, 0).unwrap(),
+            },
+            IdfEvent {
+                intensity: 56.0,
+                duration: 7,
+                fromtime: Utc.with_ymd_and_hms(2000, 1, 1, 0, 15, 0).unwrap(),
+                totime: Utc.with_ymd_and_hms(2000, 1, 1, 0, 21, 0).unwrap(),
+            },
+            IdfEvent {
+                intensity: 77.0,
+                duration: 10,
+                fromtime: Utc.with_ymd_and_hms(2000, 1, 1, 0, 15, 0).unwrap(),
+                totime: Utc.with_ymd_and_hms(2000, 1, 1, 0, 24, 0).unwrap(),
+            },
+            IdfEvent {
+                intensity: 102.0,
+                duration: 15,
+                fromtime: Utc.with_ymd_and_hms(2000, 1, 1, 0, 11, 0).unwrap(),
+                totime: Utc.with_ymd_and_hms(2000, 1, 1, 0, 25, 0).unwrap(),
+            },
+        ];
+
+        let values: Vec<_> = collect_idf_events(&durations, data);
+
+        assert_eq!(values.len(), expected.len());
+
+        for (val, exp) in values.into_iter().zip(expected.into_iter()) {
+            assert_eq!(val, exp);
+        }
+    }
+}

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use util::{DbPools, PooledPgConn};
 
 use crate::{
-    error::{self, internal_error, not_found_error, Error},
+    error::{internal_error, not_found_error, Error},
     patchwork::{self, Patch, PatchworkLabel, PatchworkTimeseriesTables},
 };
 
@@ -178,7 +178,7 @@ pub async fn idf_event_handler(
     .unwrap();
 
     // TODO: this should be handled by auth
-    let conn = pools.open.get().await.map_err(error::internal_error)?;
+    let conn = pools.open.get().await.map_err(internal_error)?;
 
     let data = fetch_rain_data(patches, &conn)
         .await
@@ -219,10 +219,7 @@ pub async fn idf_event_availability_handler(
     State(patchwork_tables): State<PatchworkTimeseriesTables>,
 ) -> Result<Json<IdfEventAvailability>, (StatusCode, String)> {
     // TODO: need to implement this also for restricted?
-    let ot = patchwork_tables
-        .open
-        .read()
-        .map_err(error::internal_error)?;
+    let ot = patchwork_tables.open.read().map_err(internal_error)?;
 
     // TODO: not sure how performant this is, maybe faster to check the DB?
     let stations: HashSet<_> = ot

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -86,11 +86,11 @@ async fn fetch_rain_data(
         .map(|patch| async move {
             conn.query(
                 "SELECT obstime, corrected \
-                 FROM legacy.data \
-                 WHERE timeseries = $1 \
-                   AND corrected IS NOT NULL \
-                   AND quality_code != 7 \
-                   AND obstime BETWEEN $2 AND $3",
+                FROM legacy.data \
+                WHERE timeseries = $1 \
+                    AND corrected IS NOT NULL \
+                    AND quality_code != 7 \
+                    AND obstime BETWEEN $2 AND $3",
                 &[&patch.tsid, &patch.from, &patch.to],
             )
             .await

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -183,13 +183,14 @@ pub async fn idf_event_handler(
         tables.open,
         Some(tables.restricted),
     )
-    .map_err(internal_error)?
-    .ok_or_else(|| {
-        (
+    .map_err(internal_error)?;
+
+    if patches.is_empty() {
+        return Err((
             StatusCode::NOT_FOUND,
             "No applicable timeseries in the given time period".to_string(),
-        )
-    })?;
+        ));
+    };
 
     // TODO: this should be handled by auth
     let conn = pools.open.get().await.map_err(internal_error)?;

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -83,7 +85,7 @@ async fn fetch_rain_data(
         .iter()
         .map(|patch| async move {
             conn.query(
-                "SELECT obstime, corrected, \
+                "SELECT obstime, corrected \
                  FROM legacy.data \
                  WHERE timeseries = $1 \
                    AND corrected IS NOT NULL \
@@ -157,7 +159,7 @@ pub async fn idf_event_handler(
     State(tables): State<PatchworkTimeseriesTables>,
     Query(params): Query<IdfEventParams>,
 ) -> Result<Json<IdfEventResp>, (StatusCode, String)> {
-    let label = PatchworkLabel::new(
+    let idf_event_label = PatchworkLabel::new(
         station_id,
         PRECIPITATION_PARAM_ID,
         DEFAULT_LEVEL,
@@ -167,7 +169,7 @@ pub async fn idf_event_handler(
     let patches = patchwork::get_applicable_timeseries(
         params.fromtime,
         params.totime,
-        label,
+        idf_event_label,
         tables.open,
         Some(tables.restricted),
     )
@@ -205,6 +207,31 @@ pub async fn idf_event_handler(
         unit: params.unit,
         values,
     }))
+}
+
+/// Response struct returned by the availability endpoint
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct IdfEventAvailability {
+    pub stations: HashSet<i32>,
+}
+
+pub async fn idf_event_availability_handler(
+    State(patchwork_tables): State<PatchworkTimeseriesTables>,
+) -> Result<Json<IdfEventAvailability>, (StatusCode, String)> {
+    // TODO: need to implement this also for restricted?
+    let ot = patchwork_tables
+        .open
+        .read()
+        .map_err(error::internal_error)?;
+
+    // TODO: not sure how performant this is, maybe faster to check the DB?
+    let stations: HashSet<_> = ot
+        .keys()
+        .filter(|label| label.param_id == PRECIPITATION_PARAM_ID)
+        .map(|label| label.station_id)
+        .collect();
+
+    Ok(Json(IdfEventAvailability { stations }))
 }
 
 #[cfg(test)]

--- a/egress/src/reports/idf_event.rs
+++ b/egress/src/reports/idf_event.rs
@@ -246,11 +246,17 @@ pub async fn idf_event_handler(
     }))
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct IdfAvailable {
+    station_id: i32,
+    permit: i32,
+}
+
 /// Response struct returned by the availability endpoint
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct IdfEventAvailabilityResp {
     /// List of stations for which IDF calculation is possible
-    pub stations: Vec<i32>,
+    pub stations: Vec<IdfAvailable>,
 }
 
 fn is_idf_event_timeseries(label: &PatchworkLabel) -> bool {
@@ -268,9 +274,12 @@ pub async fn idf_event_availability_handler(
     // TODO: not sure how performant this is, maybe we need a different data structure?
     // TODO: add timeranges and permits for the different stations?
     let mut stations: Vec<_> = ot
-        .keys()
-        .filter(|label| is_idf_event_timeseries(label))
-        .map(|label| label.station_id)
+        .iter()
+        .filter(|(label, _)| is_idf_event_timeseries(label))
+        .map(|(label, fills)| IdfAvailable {
+            station_id: label.station_id,
+            permit: fills[0].permit,
+        })
         .collect();
 
     if let Some(roles) = roles {
@@ -282,7 +291,10 @@ pub async fn idf_event_availability_handler(
                 // NOTE: All fills should have the same permit id since restrictions are applied to whole
                 // stations or single params
                 .filter(|(_, fills)| roles.contains(&fills[0].permit))
-                .map(|(label, _)| label.station_id),
+                .map(|(label, fills)| IdfAvailable {
+                    station_id: label.station_id,
+                    permit: fills[0].permit,
+                }),
         );
     }
 

--- a/egress/src/reports/idf_station.rs
+++ b/egress/src/reports/idf_station.rs
@@ -28,7 +28,7 @@ pub enum IdfUnit {
 #[serde(rename_all = "camelCase")]
 pub struct IdfValue {
     /// Duration of the precipitation event [min]
-    duration: i32,
+    duration: u32,
     /// Expected time between events of computed intensity [years]
     frequency: i32,
     /// Computed rainfall intensity value [mm]
@@ -42,7 +42,7 @@ pub struct IdfValue {
 #[cfg(feature = "integration_tests")]
 impl IdfValue {
     pub fn new(
-        duration: i32,
+        duration: u32,
         frequency: i32,
         intensity: f64,
         lower_interval: f64,
@@ -131,7 +131,7 @@ pub struct IdfStationAvailability {
 }
 
 /// Converts value [mm] and duration [minutes] to intensiry in [liter per second per hectare]
-fn mm_to_lsha(val: f64, duration: i32) -> f64 {
+pub fn mm_to_lsha(val: f64, duration: u32) -> f64 {
     1e4 / 60.0 * val / duration as f64
 }
 

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -215,7 +215,7 @@ wARDennWSrMRamnmbyLO6jno3N9mNFtq
 }
 
 pub fn mock_message_priority() -> MessagePriorityDefaultTable {
-    let from: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 12, 1, 0, 0, 0).unwrap();
+    let from: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 12, 31, 23, 0, 0).unwrap();
     let to: DateTime<Utc> = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
 
     MessagePriorityDefaultTable::from([
@@ -231,15 +231,22 @@ pub fn mock_message_priority() -> MessagePriorityDefaultTable {
             (501, 225),
             MessagePriority::new(9000, Timerange::new(Some(from), None)),
         ),
-        // The next two are needed for IDF event
+        // The next ones are needed for IDF event
         (
             (514, 105),
             MessagePriority::new(100, Timerange::new(Some(from), Some(to))),
         ),
         (
-            // Random type id, not sure which are the ones that are actually used for this
+            // This is needed to check that our patches are sorted
+            (501, 105),
+            MessagePriority::new(
+                200,
+                Timerange::new(Some(from - Duration::hours(1)), Some(from)),
+            ),
+        ),
+        (
             (508, 105),
-            MessagePriority::new(9000, Timerange::new(Some(to), None)),
+            MessagePriority::new(300, Timerange::new(Some(to), None)),
         ),
     ])
 }

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -279,12 +279,12 @@ pub async fn update_patchwork_table(
     table: Arc<RwLock<PatchworkTimeseriesTable>>,
 ) {
     let db_list = fetch_timeseries_list_from_database(conn).await.unwrap();
-    let message_prioity = mock_message_priority();
+    let message_priority = mock_message_priority();
     // Empty exceptions, could mock them in the future
     let exceptions = HashMap::new();
 
     let new_table =
-        create_patchwork_timeseries_table(db_list, message_prioity, exceptions).unwrap();
+        create_patchwork_timeseries_table(db_list, message_priority, exceptions).unwrap();
 
     let mut writer = table.write().unwrap();
     *writer = new_table;

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -15,7 +15,10 @@ use tokio::task::JoinHandle;
 use tokio_postgres::NoTls;
 use tokio_util::sync::CancellationToken;
 
-use lard_egress::patchwork::{Fill, PatchworkLabel, PatchworkTimeseriesTables};
+use lard_egress::patchwork::{
+    create_patchwork_timeseries_table, fetch_timeseries_list_from_database, MessagePriority,
+    MessagePriorityDefaultTable, PatchworkTables, PatchworkTimeseriesTable, Timerange,
+};
 use lard_ingestion::{
     get_conversions,
     util::{
@@ -24,7 +27,7 @@ use lard_ingestion::{
         qc_pipelines::load_pipelines,
     },
 };
-use util::DbPools;
+use util::{DbPools, PooledPgConn};
 
 #[derive(Clone, Copy)]
 pub enum TestObsType {
@@ -86,8 +89,7 @@ impl TestData<'_> {
     // 20240101010000,0.0,0.0,...
     // ...
     // ```
-    pub fn obsinn_message(&self) -> String {
-        let scalar_val = 0.0;
+    pub fn obsinn_message(&self, scalar_val: f64) -> String {
         let nonscalar_val = "test";
 
         let values = self
@@ -110,6 +112,16 @@ impl TestData<'_> {
         }
 
         msg.join("\n")
+    }
+
+    /// Creates an obsimm message where all values are zeros
+    pub fn obsinn_zeros(&self) -> String {
+        self.obsinn_message(0.0)
+    }
+
+    /// Creates an obsimm message where all values are ones
+    pub fn obsinn_ones(&self) -> String {
+        self.obsinn_message(1.0)
     }
 
     fn obsinn_header(&self) -> String {
@@ -184,6 +196,8 @@ pub fn mock_level_table() -> LevelTable {
         (211, Level::new(2, levels::Unit::M, levels::Direction::Up)),
         (81, Level::new(10, levels::Unit::M, levels::Direction::Up)),
         (3, Level::new(20, levels::Unit::Cm, levels::Direction::Down)),
+        // Needed for IDF event
+        (105, Level::new(2, levels::Unit::M, levels::Direction::Up)),
     ]);
 
     Arc::new(RwLock::new(param_level))
@@ -200,23 +214,34 @@ wARDennWSrMRamnmbyLO6jno3N9mNFtq
     .unwrap()
 }
 
-pub fn mock_patchwork_table() -> PatchworkTimeseriesTables {
-    let t1: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 12, 1, 0, 0, 0).unwrap();
-    let t2: DateTime<Utc> = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
-    let label1 = PatchworkLabel::new(10001, 211, Some(0), Some(0));
-    let label2 = PatchworkLabel::new(99995, 211, Some(0), Some(0));
-    // create a patchwork table for at least one label
-    let mut patchwork: HashMap<PatchworkLabel, Vec<Fill>> = HashMap::new();
-    patchwork.insert(
-        label1,
-        vec![Fill::new(t1, Some(t2), 1, 1), Fill::new(t2, None, 2, 1)],
-    );
-    let mut patchwork_restricted: HashMap<PatchworkLabel, Vec<Fill>> = HashMap::new();
-    patchwork_restricted.insert(
-        label2,
-        vec![Fill::new(t1, Some(t2), 1, 1), Fill::new(t2, None, 2, 1)],
-    );
-    PatchworkTimeseriesTables::new(patchwork, patchwork_restricted)
+pub fn mock_message_priority() -> MessagePriorityDefaultTable {
+    let from: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 12, 1, 0, 0, 0).unwrap();
+    let to: DateTime<Utc> = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+
+    MessagePriorityDefaultTable::from([
+        (
+            (508, 211),
+            MessagePriority::new(9000, Timerange::new(Some(from), Some(to))),
+        ),
+        (
+            (501, 211),
+            MessagePriority::new(9000, Timerange::new(Some(to), None)),
+        ),
+        (
+            (501, 225),
+            MessagePriority::new(9000, Timerange::new(Some(from), None)),
+        ),
+        // The next two are needed for IDF event
+        (
+            (514, 105),
+            MessagePriority::new(100, Timerange::new(Some(from), Some(to))),
+        ),
+        (
+            // Random type id, not sure which are the ones that are actually used for this
+            (508, 105),
+            MessagePriority::new(9000, Timerange::new(Some(to), None)),
+        ),
+    ])
 }
 
 pub async fn create_db_pools() -> DbPools {
@@ -243,7 +268,29 @@ pub async fn create_db_pools() -> DbPools {
     }
 }
 
-pub async fn wrapper_setup() -> (DbPools, JoinHandle<()>, CancellationToken) {
+// Create empty patchwork tables, these must be updated inside the tests that need the
+// patchwork timeseries, since they require knowledge of the timeseries present in the database
+pub fn empty_patchwork_tables() -> PatchworkTables {
+    PatchworkTables::new(HashMap::new(), HashMap::new())
+}
+
+pub async fn update_patchwork_table(
+    conn: &PooledPgConn<'_>,
+    table: Arc<RwLock<PatchworkTimeseriesTable>>,
+) {
+    let db_list = fetch_timeseries_list_from_database(conn).await.unwrap();
+    let message_prioity = mock_message_priority();
+    // Empty exceptions, could mock them in the future
+    let exceptions = HashMap::new();
+
+    let new_table =
+        create_patchwork_timeseries_table(db_list, message_prioity, exceptions).unwrap();
+
+    let mut writer = table.write().unwrap();
+    *writer = new_table;
+}
+
+pub async fn wrapper_setup() -> (DbPools, PatchworkTables, JoinHandle<()>, CancellationToken) {
     let db_pools = create_db_pools().await;
 
     let s3_bucket = Arc::from(
@@ -260,15 +307,17 @@ pub async fn wrapper_setup() -> (DbPools, JoinHandle<()>, CancellationToken) {
     // set up cancellation token and signal catcher to detect premature shutdown
     let cancel_token = CancellationToken::new();
 
+    let patchwork_tables = empty_patchwork_tables();
+
     let egress = tokio::spawn(lard_egress::run(
         db_pools.clone(),
         s3_bucket,
-        mock_patchwork_table(),
+        patchwork_tables.clone(),
         mock_auth_certs(),
         cancel_token.clone(),
     ));
 
-    (db_pools, egress, cancel_token)
+    (db_pools, patchwork_tables, egress, cancel_token)
 }
 
 pub async fn db_cleanup(db_pools: DbPools) {
@@ -284,7 +333,7 @@ pub async fn db_cleanup(db_pools: DbPools) {
 }
 
 pub async fn e2e_test_wrapper<T: Future<Output = ()>>(test: T) {
-    let (db_pools, mut egress, cancel_token) = wrapper_setup().await;
+    let (db_pools, _, mut egress, cancel_token) = wrapper_setup().await;
 
     let rove_connector = Connector {
         pool: db_pools.open.clone(),

--- a/integration_tests/tests/common/mod.rs
+++ b/integration_tests/tests/common/mod.rs
@@ -114,12 +114,12 @@ impl TestData<'_> {
         msg.join("\n")
     }
 
-    /// Creates an obsimm message where all values are zeros
+    // Creates an obsimm message where all values are zeros
     pub fn obsinn_zeros(&self) -> String {
         self.obsinn_message(0.0)
     }
 
-    /// Creates an obsimm message where all values are ones
+    // Creates an obsimm message where all values are ones
     pub fn obsinn_ones(&self) -> String {
         self.obsinn_message(1.0)
     }

--- a/integration_tests/tests/end_to_end.rs
+++ b/integration_tests/tests/end_to_end.rs
@@ -282,24 +282,6 @@ async fn test_latest_endpoint() {
 }
 
 #[tokio::test]
-async fn test_patchwork_endpoint_failure() {
-    // FIXME: this is running against an empty patchwork table
-    let cases = vec![
-        (
-            "?stationids=10001&params=12345&levels=0&sensors=0&from=2024-12-31T23:00:00Z&to=2025-01-01T01:30:00Z",
-        ), // made up param, shouldn't exist
-    ];
-    e2e_test_wrapper(async {
-        for query in cases {
-            let url = format!("http://localhost:3000/patchwork{query:?}");
-            let resp = reqwest::get(url).await.unwrap();
-            assert!(resp.status().is_client_error()); // expect 404
-        }
-    })
-    .await
-}
-
-#[tokio::test]
 async fn test_timeslice_endpoint() {
     e2e_test_wrapper(async {
         let timestamp = Utc.with_ymd_and_hms(2024, 1, 1, 1, 0, 0).unwrap();

--- a/integration_tests/tests/end_to_end.rs
+++ b/integration_tests/tests/end_to_end.rs
@@ -4,9 +4,7 @@ use chronoutil::RelativeDuration;
 use rove::data_switch::{DataConnector, SpaceSpec, TimeSpec, Timestamp};
 use tokio_postgres::NoTls;
 
-use lard_egress::{
-    timeseries::Timeseries, LatestResp, PatchworkAvailableResp, TimeseriesResp, TimesliceResp,
-};
+use lard_egress::{timeseries::Timeseries, LatestResp, TimeseriesResp, TimesliceResp};
 use lard_ingestion::{
     util::{levels::param_get_level, permissions::timeseries_get_permit},
     KldataResp,
@@ -295,22 +293,6 @@ async fn test_patchwork_endpoint_failure() {
             let url = format!("http://localhost:3000/patchwork{query:?}");
             let resp = reqwest::get(url).await.unwrap();
             assert!(resp.status().is_client_error()); // expect 404
-        }
-    })
-    .await
-}
-
-#[tokio::test]
-async fn test_patchwork_available_endpoint() {
-    // currently 1 unrestricted label in the mock
-    let cases = vec![("", 1)];
-    e2e_test_wrapper(async {
-        for (query, n_data_found) in cases {
-            let url = format!("http://localhost:3000/patchwork/available{query}");
-            let resp = reqwest::get(url).await.unwrap();
-            assert!(resp.status().is_success());
-            let json: PatchworkAvailableResp = resp.json().await.unwrap();
-            assert_eq!(json.available.len(), n_data_found);
         }
     })
     .await

--- a/integration_tests/tests/end_to_end.rs
+++ b/integration_tests/tests/end_to_end.rs
@@ -111,7 +111,7 @@ async fn test_stations_endpoint_irregular() {
         };
 
         let client = reqwest::Client::new();
-        let ingestor_resp = ingest_data(&client, ts.obsinn_message()).await;
+        let ingestor_resp = ingest_data(&client, ts.obsinn_zeros()).await;
         assert_eq!(ingestor_resp.res, 0);
 
         for param in ts.params {
@@ -174,7 +174,7 @@ async fn test_stations_endpoint_regular() {
     for ts in cases {
         e2e_test_wrapper(async {
             let client = reqwest::Client::new();
-            let ingestor_resp = ingest_data(&client, ts.obsinn_message()).await;
+            let ingestor_resp = ingest_data(&client, ts.obsinn_zeros()).await;
             assert_eq!(ingestor_resp.res, 0);
 
             let resolution = "PT1H";
@@ -219,7 +219,7 @@ async fn test_stations_endpoint_errors() {
             };
 
             let client = reqwest::Client::new();
-            let ingestor_resp = ingest_data(&client, ts.obsinn_message()).await;
+            let ingestor_resp = ingest_data(&client, ts.obsinn_zeros()).await;
             assert_eq!(ingestor_resp.res, 0);
 
             for _ in ts.params {
@@ -268,7 +268,7 @@ async fn test_latest_endpoint() {
 
             let client = reqwest::Client::new();
             for ts in test_data {
-                let ingestor_resp = ingest_data(&client, ts.obsinn_message()).await;
+                let ingestor_resp = ingest_data(&client, ts.obsinn_zeros()).await;
                 assert_eq!(ingestor_resp.res, 0);
             }
 
@@ -343,7 +343,7 @@ async fn test_timeslice_endpoint() {
 
         let client = reqwest::Client::new();
         for ts in &test_data {
-            let ingestor_resp = ingest_data(&client, ts.obsinn_message()).await;
+            let ingestor_resp = ingest_data(&client, ts.obsinn_zeros()).await;
             assert_eq!(
                 ingestor_resp.res, 0,
                 "ingestor_resp.message: {}",
@@ -398,7 +398,7 @@ async fn test_rove_connector() {
         let pool = bb8::Pool::builder().build(manager).await.unwrap();
         let connector = rove_connector::Connector { pool };
 
-        let ingestor_resp = ingest_data(&client, ts.obsinn_message()).await;
+        let ingestor_resp = ingest_data(&client, ts.obsinn_zeros()).await;
         assert_eq!(ingestor_resp.res, 0);
 
         let resolution = "PT1H";

--- a/integration_tests/tests/end_to_end.rs
+++ b/integration_tests/tests/end_to_end.rs
@@ -283,6 +283,7 @@ async fn test_latest_endpoint() {
 
 #[tokio::test]
 async fn test_patchwork_endpoint_failure() {
+    // FIXME: this is running against an empty patchwork table
     let cases = vec![
         (
             "?stationids=10001&params=12345&levels=0&sensors=0&from=2024-12-31T23:00:00Z&to=2025-01-01T01:30:00Z",

--- a/integration_tests/tests/idf_station.rs
+++ b/integration_tests/tests/idf_station.rs
@@ -7,6 +7,8 @@ use lard_egress::reports::{
     IdfMetadata, IdfStationAvailability, IdfStationResp, IdfUnit, IdfValue,
 };
 use tokio_util::sync::CancellationToken;
+
+use crate::common::empty_patchwork_tables;
 pub mod common;
 
 pub async fn s3_test_wrapper((path, content): (&str, &str), test: impl AsyncFnOnce() -> ()) {
@@ -33,7 +35,7 @@ pub async fn s3_test_wrapper((path, content): (&str, &str), test: impl AsyncFnOn
     let mut egress = tokio::spawn(lard_egress::run(
         db_pools.clone(),
         bucket,
-        common::mock_patchwork_table(),
+        empty_patchwork_tables(),
         common::mock_auth_certs(),
         cancel_token.clone(),
     ));

--- a/integration_tests/tests/legacy.rs
+++ b/integration_tests/tests/legacy.rs
@@ -25,6 +25,15 @@ const KAFKA_CHECKED_TOPIC: &str = "checked";
 const KAFKA_CHECKED_HIST_TOPIC: &str = "hist.checked";
 const KAFKA_GROUP: &str = "lard_test";
 
+// fake token created with roles 9,5 so should be able to see data
+const RESTRICTED_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.\
+    eyJyZXNvdXJjZV9hY2Nlc3MiOnsiT0RBIjp7In\
+    JvbGVzIjpbInBlcm1pdGlkLTkiLCJwZXJtaXRp\
+    ZC01Il19fSwiZXhwIjoyMDcxOTE2MTY2fQ.K9V\
+    Syzl583Ck5pAvWj1dBHZ57VPeG00XyZY686BCL\
+    EtpCXAgB2I1FunROt3Vl1sP2mohnhbb5GOZInx\
+    _y-RW1LBHEeZRK-expKC10ipYsqUbG8-P0fw8HFH7vedMExHO";
+
 struct IngestData<'a> {
     timeseries: Vec<TestData<'a>>,
     expected_open: usize,
@@ -421,7 +430,7 @@ async fn test_patchwork_endpoint() {
             &from=2024-12-31T23:00:00Z\
             &to=2025-01-01T01:30:00Z",
             None, // no token, no data access
-            404, // just don't see it... 
+            404,  // just don't see it...
             0,
         ),
         (
@@ -431,8 +440,7 @@ async fn test_patchwork_endpoint() {
             &sensors=0\
             &from=2024-12-31T23:00:00Z\
             &to=2025-01-01T01:30:00Z",
-            // fake token created with roles 9,5 so should be able to see data
-            Some("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.eyJyZXNvdXJjZV9hY2Nlc3MiOnsiT0RBIjp7InJvbGVzIjpbInBlcm1pdGlkLTkiLCJwZXJtaXRpZC01Il19fSwiZXhwIjoyMDcxOTE2MTY2fQ.K9VSyzl583Ck5pAvWj1dBHZ57VPeG00XyZY686BCLEtpCXAgB2I1FunROt3Vl1sP2mohnhbb5GOZInx_y-RW1LBHEeZRK-expKC10ipYsqUbG8-P0fw8HFH7vedMExHO"),
+            Some(RESTRICTED_TOKEN),
             200,
             3,
         ),
@@ -670,7 +678,6 @@ async fn test_idf_failure() {
     let start_time = Utc.with_ymd_and_hms(2024, 12, 31, 23, 40, 0).unwrap();
     let end_time = Utc.with_ymd_and_hms(2025, 1, 1, 0, 9, 0).unwrap();
 
-    let ts_len = 30;
     let station_id = 10001;
     let test_data = IngestData::new(vec![
         TestData {
@@ -679,7 +686,7 @@ async fn test_idf_failure() {
             start_time,
             period: Duration::minutes(1),
             type_id: 514,
-            len: ts_len,
+            len: 30,
         },
         TestData {
             station_id,
@@ -687,7 +694,7 @@ async fn test_idf_failure() {
             start_time,
             period: Duration::minutes(1),
             type_id: 508,
-            len: ts_len,
+            len: 30,
         },
     ]);
 
@@ -705,6 +712,90 @@ async fn test_idf_failure() {
 
             // Since the data is not QCed we won't get a positive response (not found error)
             assert!(resp.status().is_client_error(),);
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_idf_event_restricted() {
+    let start_time = Utc.with_ymd_and_hms(2024, 12, 31, 23, 40, 0).unwrap();
+    let station_id = 99995;
+
+    let test_data = IngestData::new(vec![
+        TestData {
+            station_id,
+            params: vec![Param::new("RR_01")],
+            start_time,
+            period: Duration::minutes(1),
+            type_id: 514,
+            len: 30,
+        },
+        TestData {
+            station_id,
+            params: vec![Param::new("RR_01")],
+            start_time,
+            period: Duration::minutes(1),
+            type_id: 508,
+            len: 30,
+        },
+    ]);
+
+    let cases = [(
+        // Should only get the first timeseries
+        "single duration",
+        start_time,
+        start_time + Duration::minutes(10),
+        "10",
+        vec![IdfEvent::new(
+            10.0,
+            10,
+            start_time,
+            start_time + Duration::minutes(9),
+        )],
+    )];
+
+    e2e_test_wrapper_legacy(
+        async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
+            ingest_raw(&test_data, producer, db_pools.clone(), tables).await;
+
+            // HACK: need to set corrected and quality_code to be able to compute idf event
+            let conn = db_pools.restricted.get().await.unwrap();
+            conn.execute(
+                "UPDATE legacy.data SET corrected = 1.0, quality_code = 1",
+                &[],
+            )
+            .await
+            .unwrap();
+
+            for (title, from, to, duration, expected) in cases {
+                let url = format!(
+                    "http://localhost:3000/reports/idf/event/{station_id}\
+                    ?fromtime={from}\
+                    &totime={to}\
+                    &durations={duration}",
+                );
+
+                let resp = Client::new()
+                    .get(url)
+                    .bearer_auth(RESTRICTED_TOKEN)
+                    .send()
+                    .await
+                    .unwrap();
+                assert!(
+                    resp.status().is_success(),
+                    "{title}: {}",
+                    resp.text().await.unwrap()
+                );
+
+                let json: IdfEventResp = resp.json().await.unwrap();
+                assert_eq!(json.station_id, station_id, "{title}");
+                assert_eq!(json.values.len(), expected.len(), "{title}");
+
+                for (val, exp) in json.values.into_iter().zip(expected) {
+                    assert_eq!(val, exp, "{title}")
+                }
+            }
         },
     )
     .await

--- a/integration_tests/tests/legacy.rs
+++ b/integration_tests/tests/legacy.rs
@@ -8,7 +8,7 @@ use reqwest::StatusCode;
 
 use lard_egress::{
     patchwork::PatchworkTables,
-    reports::{IdfEvent, IdfEventAvailability, IdfEventResp, DEFAULT_DURATIONS},
+    reports::{IdfEvent, IdfEventAvailabilityResp, IdfEventResp, DEFAULT_DURATIONS},
     PatchworkAvailableResp, PatchworkResp,
 };
 
@@ -595,7 +595,7 @@ async fn test_idf_event_availability() {
                 let resp = request.send().await.unwrap();
                 assert!(resp.status().is_success(), "{}", resp.text().await.unwrap());
 
-                let json: IdfEventAvailability = resp.json().await.unwrap();
+                let json: IdfEventAvailabilityResp = resp.json().await.unwrap();
                 assert_eq!(json.stations.len(), expected_ts, "{json:?}");
             }
         },

--- a/integration_tests/tests/legacy.rs
+++ b/integration_tests/tests/legacy.rs
@@ -519,6 +519,8 @@ async fn test_patchwork_endpoint() {
 
 #[tokio::test]
 async fn test_idf_event_availability() {
+    let cases = [(Some(RESTRICTED_TOKEN), 3), (None, 2)];
+
     e2e_test_wrapper_legacy(
         async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
             let start_time = Utc.with_ymd_and_hms(2024, 12, 31, 23, 50, 0).unwrap();
@@ -539,16 +541,33 @@ async fn test_idf_event_availability() {
                     type_id: 508,
                     len: 20,
                 },
+                TestData {
+                    station_id: 99995,
+                    params: vec![Param::new("RR_01")],
+                    start_time,
+                    period: Duration::minutes(1),
+                    type_id: 508,
+                    len: 20,
+                },
             ]);
 
             ingest_raw(&test_data, producer, db_pools, tables).await;
 
             let url = "http://localhost:3000/reports/idf/event";
-            let resp = reqwest::get(url).await.unwrap();
-            assert!(resp.status().is_success(), "{}", resp.text().await.unwrap());
 
-            let json: IdfEventAvailability = resp.json().await.unwrap();
-            assert_eq!(json.stations.len(), test_data.timeseries.len(), "{json:?}");
+            for (token, expected_ts) in cases {
+                let client = Client::new();
+                let request = match token {
+                    Some(t) => client.get(url).bearer_auth(t),
+                    None => client.get(url),
+                };
+
+                let resp = request.send().await.unwrap();
+                assert!(resp.status().is_success(), "{}", resp.text().await.unwrap());
+
+                let json: IdfEventAvailability = resp.json().await.unwrap();
+                assert_eq!(json.stations.len(), expected_ts, "{json:?}");
+            }
         },
     )
     .await

--- a/integration_tests/tests/legacy.rs
+++ b/integration_tests/tests/legacy.rs
@@ -368,7 +368,7 @@ async fn test_kafka_raw() {
 
 #[tokio::test]
 async fn test_patchwork_available_endpoint() {
-    // We insert a single timeseries so we will only a single label
+    // We insert a single timeseries so we will only get out a single label
     let n_labels = 1;
 
     e2e_test_wrapper_legacy(
@@ -723,7 +723,7 @@ async fn test_idf_event() {
 }
 
 #[tokio::test]
-async fn test_idf_failure() {
+async fn test_idf_event_failure() {
     let start_time = Utc.with_ymd_and_hms(2024, 12, 31, 23, 40, 0).unwrap();
     let end_time = Utc.with_ymd_and_hms(2025, 1, 1, 0, 9, 0).unwrap();
 
@@ -760,7 +760,11 @@ async fn test_idf_failure() {
             let resp = reqwest::get(url).await.unwrap();
 
             // Since the data is not QCed we won't get a positive response (not found error)
-            assert!(resp.status().is_client_error(),);
+            assert!(
+                resp.status().is_client_error(),
+                "{}",
+                resp.text().await.unwrap()
+            );
         },
     )
     .await

--- a/integration_tests/tests/legacy.rs
+++ b/integration_tests/tests/legacy.rs
@@ -2,6 +2,7 @@ use std::{panic::AssertUnwindSafe, time::Instant};
 
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use futures::FutureExt;
+use lard_egress::reports::IdfEventAvailable;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use reqwest::Client;
 use reqwest::StatusCode;
@@ -549,11 +550,35 @@ async fn test_patchwork_endpoint() {
 
 #[tokio::test]
 async fn test_idf_event_availability() {
-    let cases = [(Some(RESTRICTED_TOKEN), 3), (None, 2)];
+    // Message priority default times
+    let priority_switch: DateTime<Utc> = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+
+    // Timeseries start time
+    let start_time = Utc.with_ymd_and_hms(2024, 12, 31, 23, 50, 0).unwrap();
+    let cases = [
+        (
+            Some(RESTRICTED_TOKEN),
+            IdfEventAvailabilityResp {
+                stations: vec![
+                    IdfEventAvailable::new(10001, 1, start_time, Some(priority_switch)),
+                    IdfEventAvailable::new(20001, 1, priority_switch, None),
+                    IdfEventAvailable::new(99995, 5, priority_switch, None),
+                ],
+            },
+        ),
+        (
+            None,
+            IdfEventAvailabilityResp {
+                stations: vec![
+                    IdfEventAvailable::new(10001, 1, start_time, Some(priority_switch)),
+                    IdfEventAvailable::new(20001, 1, priority_switch, None),
+                ],
+            },
+        ),
+    ];
 
     e2e_test_wrapper_legacy(
         async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
-            let start_time = Utc.with_ymd_and_hms(2024, 12, 31, 23, 50, 0).unwrap();
             let test_data = IngestData::new(vec![
                 TestData {
                     station_id: 10001,
@@ -585,7 +610,7 @@ async fn test_idf_event_availability() {
 
             let url = "http://localhost:3000/reports/idf/event";
 
-            for (token, expected_ts) in cases {
+            for (token, expected) in cases {
                 let client = Client::new();
                 let request = match token {
                     Some(t) => client.get(url).bearer_auth(t),
@@ -595,8 +620,12 @@ async fn test_idf_event_availability() {
                 let resp = request.send().await.unwrap();
                 assert!(resp.status().is_success(), "{}", resp.text().await.unwrap());
 
-                let json: IdfEventAvailabilityResp = resp.json().await.unwrap();
-                assert_eq!(json.stations.len(), expected_ts, "{json:?}");
+                let mut json: IdfEventAvailabilityResp = resp.json().await.unwrap();
+
+                // Sort so that the stations are in order
+                json.stations.sort_by_key(|s| s.station_id);
+
+                assert_eq!(json, expected);
             }
         },
     )

--- a/integration_tests/tests/legacy.rs
+++ b/integration_tests/tests/legacy.rs
@@ -12,18 +12,110 @@ use lard_egress::{
     PatchworkAvailableResp, PatchworkResp,
 };
 
-use lard_ingestion::get_conversions;
+use lard_ingestion::{get_conversions, util::permissions::timeseries_get_permit};
 use util::{DbPools, PooledPgConn};
 
 pub mod common;
 use common::{Param, TestData};
 
-use crate::common::update_patchwork_table;
+use crate::common::{mock_permit_tables, update_patchwork_table};
 
 const KAFKA_RAW_TOPIC: &str = "raw";
 const KAFKA_CHECKED_TOPIC: &str = "checked";
 const KAFKA_CHECKED_HIST_TOPIC: &str = "hist.checked";
 const KAFKA_GROUP: &str = "lard_test";
+
+struct IngestData<'a> {
+    timeseries: Vec<TestData<'a>>,
+    expected_open: usize,
+    expected_restricted: usize,
+}
+
+impl<'a> IngestData<'a> {
+    fn new(data: Vec<TestData<'a>>) -> Self {
+        let mut expected_open = 0;
+        let mut expected_restricted = 0;
+
+        // Calculate expected rows to be found in the database after ingestion
+        // To be honest this feels like another hack
+        for ts in &data {
+            for param in &ts.params {
+                let permit = timeseries_get_permit(
+                    mock_permit_tables(),
+                    ts.station_id,
+                    ts.type_id,
+                    Some(param.id),
+                )
+                .unwrap();
+                if permit == Some(1) {
+                    expected_open += ts.len;
+                } else {
+                    expected_restricted += ts.len
+                }
+            }
+        }
+
+        Self {
+            timeseries: data,
+            expected_open,
+            expected_restricted,
+        }
+    }
+}
+
+// Helper function that waits for data to be available
+async fn wait_for_db_readiness(conn: &PooledPgConn<'_>, expected_rows: usize) {
+    let timeout = std::time::Duration::from_secs(10);
+    let timeout_start = Instant::now();
+    loop {
+        if let Ok(rows) = conn.query("SELECT timeseries FROM legacy.data", &[]).await {
+            if rows.len() == expected_rows {
+                break;
+            }
+        };
+
+        if timeout_start.elapsed() > timeout {
+            panic!("Timed out waiting for data to appear")
+        }
+    }
+}
+
+/// Helper function that ingests data into the raw queue, waits for it to be available, and updates
+/// the patchwork tables
+async fn ingest_raw(
+    data: &IngestData<'_>,
+    producer: FutureProducer,
+    pools: DbPools,
+    tables: PatchworkTables,
+) {
+    for ts in &data.timeseries {
+        producer
+            .send_result(
+                FutureRecord::to(KAFKA_RAW_TOPIC)
+                    .key("")
+                    .payload(&ts.obsinn_zeros()),
+            )
+            .unwrap()
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    let open_conn = pools.open.get().await.unwrap();
+    let restricted_conn = pools.restricted.get().await.unwrap();
+
+    // As we have no way to sync with message processing in kvkafka ingestion, we just keep
+    // trying to fetch data with a timeout
+    tokio::join!(
+        wait_for_db_readiness(&open_conn, data.expected_open),
+        wait_for_db_readiness(&restricted_conn, data.expected_restricted),
+    );
+
+    tokio::join!(
+        update_patchwork_table(&open_conn, tables.open),
+        update_patchwork_table(&restricted_conn, tables.restricted)
+    );
+}
 
 /// Similar to e2e_test_wrapper, but adapted to use kvkafka ingestion instead of obsinn.
 pub async fn e2e_test_wrapper_legacy(
@@ -80,24 +172,6 @@ pub async fn e2e_test_wrapper_legacy(
     let (egress_result, ingestion_result) = tokio::join!(egress, ingestion);
     egress_result.unwrap();
     ingestion_result.unwrap().unwrap();
-}
-
-// As we have no way to sync with message processing in kvkafka ingestion, we just keep
-// trying to fetch data with a timeout
-async fn wait_for_db_readiness(conn: &PooledPgConn<'_>, expected_rows: usize) {
-    let timeout = std::time::Duration::from_secs(10);
-    let timeout_start = Instant::now();
-    loop {
-        if let Ok(rows) = conn.query("SELECT timeseries FROM legacy.data", &[]).await {
-            if rows.len() == expected_rows {
-                break;
-            }
-        };
-
-        if timeout_start.elapsed() > timeout {
-            panic!("Timed out waiting for data to appear")
-        }
-    }
 }
 
 #[tokio::test]
@@ -232,76 +306,54 @@ async fn test_kafka_checked() {
 
 #[tokio::test]
 async fn test_kafka_raw() {
-    e2e_test_wrapper_legacy(async |producer: FutureProducer, db_pools: DbPools, _| {
-        let ts = TestData {
-            station_id: 20001,
-            params: vec![Param::new("TA")],
-            start_time: Utc.with_ymd_and_hms(2024, 6, 6, 6, 0, 0).unwrap(),
-            period: Duration::hours(1),
-            type_id: 501,
-            len: 1,
-        };
+    e2e_test_wrapper_legacy(
+        async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
+            let test_data = IngestData::new(vec![TestData {
+                station_id: 20001,
+                params: vec![Param::with_sensor_level("TA", (0, 200))],
+                start_time: Utc.with_ymd_and_hms(2024, 6, 6, 6, 0, 0).unwrap(),
+                period: Duration::hours(1),
+                type_id: 501,
+                len: 1,
+            }]);
 
-        producer
-            .send_result(
-                FutureRecord::to(KAFKA_RAW_TOPIC)
-                    .key("")
-                    .payload(&ts.obsinn_zeros()),
-            )
-            .unwrap()
-            .await
-            .unwrap()
-            .unwrap();
+            ingest_raw(&test_data, producer, db_pools.clone(), tables).await;
 
-        // As we have no way to sync with message processing in kvkafka ingestion, we just keep
-        // trying to fetch data with a timeout
-        let expected_rows = 1;
-        let open_conn = db_pools.open.get().await.unwrap();
-        wait_for_db_readiness(&open_conn, expected_rows).await;
+            let open_conn = db_pools.open.get().await.unwrap();
+            // TODO: we do not have an API endpoint to query the flags.kvdata table
+            let data_row = open_conn
+                .query_one("SELECT timeseries, obstime, original FROM legacy.data", &[])
+                .await
+                .unwrap();
 
-        // TODO: we do not have an API endpoint to query the flags.kvdata table
-        let data_row = open_conn
-            .query_one("SELECT timeseries, obstime, original FROM legacy.data", &[])
-            .await
-            .unwrap();
+            let (timeseries, obstime, original): (i64, DateTime<Utc>, Option<f64>) =
+                (data_row.get(0), data_row.get(1), data_row.get(2));
+            assert_eq!(obstime, Utc.with_ymd_and_hms(2024, 6, 6, 6, 0, 0).unwrap());
+            assert_eq!(original, Some(0.));
 
-        let (timeseries, obstime, original): (i64, DateTime<Utc>, Option<f64>) =
-            (data_row.get(0), data_row.get(1), data_row.get(2));
-        assert_eq!(obstime, Utc.with_ymd_and_hms(2024, 6, 6, 6, 0, 0).unwrap());
-        assert_eq!(original, Some(0.));
-
-        let label_row = open_conn
-            .query_one(
-                "SELECT station_id, param_id, type_id, lvl, sensor \
+            let label_row = open_conn
+                .query_one(
+                    "SELECT station_id, param_id, type_id, lvl, sensor \
                         FROM labels.kvalobs \
                         WHERE timeseries = $1",
-                &[&timeseries],
-            )
-            .await
-            .unwrap();
+                    &[&timeseries],
+                )
+                .await
+                .unwrap();
 
-        #[allow(clippy::type_complexity)]
-        let (station_id, param_id, type_id, lvl, sensor): (
-            // should these really all be Option??
-            Option<i32>,
-            Option<i32>,
-            Option<i32>,
-            Option<i32>,
-            Option<i32>,
-        ) = (
-            label_row.get(0),
-            label_row.get(1),
-            label_row.get(2),
-            label_row.get(3),
-            label_row.get(4),
-        );
+            let station_id: i32 = label_row.get(0);
+            let param_id: i32 = label_row.get(1);
+            let type_id: i32 = label_row.get(2);
+            let lvl: i32 = label_row.get(3);
+            let sensor: i32 = label_row.get(4);
 
-        assert_eq!(station_id, Some(20001));
-        assert_eq!(param_id, Some(211));
-        assert_eq!(type_id, Some(501));
-        assert_eq!(lvl, Some(0));
-        assert_eq!(sensor, Some(0));
-    })
+            assert_eq!(station_id, 20001);
+            assert_eq!(param_id, 211);
+            assert_eq!(type_id, 501);
+            assert_eq!(lvl, 200);
+            assert_eq!(sensor, 0);
+        },
+    )
     .await
 }
 
@@ -312,31 +364,16 @@ async fn test_patchwork_available_endpoint() {
 
     e2e_test_wrapper_legacy(
         async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
-            let data = TestData {
+            let data = IngestData::new(vec![TestData {
                 station_id: 20001,
                 params: vec![Param::new("TA")],
                 start_time: Utc.with_ymd_and_hms(2024, 12, 15, 0, 0, 0).unwrap(),
                 period: Duration::hours(1),
                 type_id: 508,
                 len: 2,
-            };
+            }]);
 
-            // TODO: maybe all ingestion stuff, until request could be extracted?
-            producer
-                .send_result(
-                    FutureRecord::to(KAFKA_RAW_TOPIC)
-                        .key("")
-                        .payload(&data.obsinn_zeros()),
-                )
-                .unwrap()
-                .await
-                .unwrap()
-                .unwrap();
-
-            let open_conn = db_pools.open.get().await.unwrap();
-            let expected_open_rows = 2;
-            wait_for_db_readiness(&open_conn, expected_open_rows).await;
-            update_patchwork_table(&open_conn, tables.open.clone()).await;
+            ingest_raw(&data, producer, db_pools, tables).await;
 
             let url = "http://localhost:3000/patchwork/available";
             let resp = reqwest::get(url).await.unwrap();
@@ -404,7 +441,7 @@ async fn test_patchwork_endpoint() {
     e2e_test_wrapper_legacy(
         async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
             let t1: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 12, 31, 20, 0, 0).unwrap();
-            let test_data = [
+            let test_data = IngestData::new(vec![
                 TestData {
                     station_id: 10001,
                     params: vec![Param::new("TA")],
@@ -445,33 +482,9 @@ async fn test_patchwork_endpoint() {
                     type_id: 501,
                     len: 8,
                 },
-            ];
+            ]);
 
-            for ts in test_data {
-                producer
-                    .send_result(
-                        FutureRecord::to(KAFKA_RAW_TOPIC)
-                            .key("")
-                            .payload(&ts.obsinn_zeros()),
-                    )
-                    .unwrap()
-                    .await
-                    .unwrap()
-                    .unwrap();
-            }
-
-            let open_conn = db_pools.open.get().await.unwrap();
-            let restricted_conn = db_pools.restricted.get().await.unwrap();
-
-            let expected_open_rows = 24;
-            let expected_restricted_rows = 16;
-            tokio::join!(
-                wait_for_db_readiness(&open_conn, expected_open_rows),
-                wait_for_db_readiness(&restricted_conn, expected_restricted_rows),
-            );
-
-            // Update patchwork with the timeseries in the database
-            update_patchwork_table(&open_conn, tables.open.clone()).await;
+            ingest_raw(&test_data, producer, db_pools, tables).await;
 
             for (query, token, status, n_data_found) in cases {
                 let url = format!("http://localhost:3000/patchwork{query}");
@@ -501,15 +514,14 @@ async fn test_idf_event_availability() {
     e2e_test_wrapper_legacy(
         async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
             let start_time = Utc.with_ymd_and_hms(2024, 12, 31, 23, 50, 0).unwrap();
-            let ts_len = 20;
-            let test_data = [
+            let test_data = IngestData::new(vec![
                 TestData {
                     station_id: 10001,
                     params: vec![Param::new("RR_01")],
                     start_time,
                     period: Duration::minutes(1),
                     type_id: 514,
-                    len: ts_len,
+                    len: 20,
                 },
                 TestData {
                     station_id: 20001,
@@ -517,35 +529,18 @@ async fn test_idf_event_availability() {
                     start_time,
                     period: Duration::minutes(1),
                     type_id: 508,
-                    len: ts_len,
+                    len: 20,
                 },
-            ];
+            ]);
 
-            for ts in &test_data {
-                producer
-                    .send_result(
-                        FutureRecord::to(KAFKA_RAW_TOPIC)
-                            .key("")
-                            .payload(&ts.obsinn_zeros()),
-                    )
-                    .unwrap()
-                    .await
-                    .unwrap()
-                    .unwrap();
-            }
-
-            let open_conn = db_pools.open.get().await.unwrap();
-            let expected_open_rows = ts_len * test_data.len();
-            wait_for_db_readiness(&open_conn, expected_open_rows).await;
-
-            update_patchwork_table(&open_conn, tables.open).await;
+            ingest_raw(&test_data, producer, db_pools, tables).await;
 
             let url = "http://localhost:3000/reports/idf/event";
             let resp = reqwest::get(url).await.unwrap();
             assert!(resp.status().is_success(), "{}", resp.text().await.unwrap());
 
             let json: IdfEventAvailability = resp.json().await.unwrap();
-            assert_eq!(json.stations.len(), test_data.len(), "{json:?}");
+            assert_eq!(json.stations.len(), test_data.timeseries.len(), "{json:?}");
         },
     )
     .await
@@ -557,16 +552,15 @@ async fn test_idf_event() {
     let end_first_ts = Utc.with_ymd_and_hms(2024, 12, 31, 23, 49, 0).unwrap();
     let end_second_ts = Utc.with_ymd_and_hms(2025, 1, 1, 0, 9, 0).unwrap();
 
-    let ts_len = 30;
     let station_id = 10001;
-    let test_data = [
+    let test_data = IngestData::new(vec![
         TestData {
             station_id,
             params: vec![Param::new("RR_01")],
             start_time,
             period: Duration::minutes(1),
             type_id: 514,
-            len: ts_len,
+            len: 30,
         },
         TestData {
             station_id,
@@ -574,37 +568,34 @@ async fn test_idf_event() {
             start_time,
             period: Duration::minutes(1),
             type_id: 508,
-            len: ts_len,
+            len: 30,
         },
-    ];
+    ]);
 
-    let default_end_time = start_time.checked_add_signed(Duration::minutes(1)).unwrap();
     let cases = [
         (
-            // Only extract 2 observations for simplicity (painful)
+            // Only extract 2 timestamps for simplicity
             "default durations",
             start_time,
-            start_time.checked_add_signed(Duration::minutes(2)).unwrap(),
+            start_time + Duration::minutes(2),
             None,
-            DEFAULT_DURATIONS
-                .iter()
-                .map(|d| {
-                    let (intensity, end_time) = if *d == 1 {
-                        (1.0, start_time)
-                    } else {
-                        (2.0, default_end_time)
-                    };
-                    IdfEvent::new(intensity, *d, start_time, end_time)
-                })
+            // Skip the first element (duration = 1), since that one can only return a single
+            // timestamp
+            vec![IdfEvent::new(1.0, 1, start_time, start_time)]
+                .into_iter()
+                .chain(
+                    // All durations > 1 should return the same intensity and timestamps
+                    DEFAULT_DURATIONS[1..].iter().map(|d| {
+                        IdfEvent::new(2.0, *d, start_time, start_time + Duration::minutes(1))
+                    }),
+                )
                 .collect(),
         ),
         (
             // Should only get the first timeseries
             "single duration",
             start_time,
-            start_time
-                .checked_add_signed(Duration::minutes(10))
-                .unwrap(),
+            start_time + Duration::minutes(10),
             Some(vec![10]),
             vec![IdfEvent::new(10.0, 10, start_time, end_first_ts)],
         ),
@@ -612,9 +603,7 @@ async fn test_idf_event() {
             // Should get both timeseries
             "multiple durations",
             start_time,
-            start_time
-                .checked_add_signed(Duration::minutes(50))
-                .unwrap(),
+            start_time + Duration::minutes(50),
             Some(vec![10, 40]),
             vec![
                 IdfEvent::new(10.0, 10, start_time, end_first_ts),
@@ -625,25 +614,10 @@ async fn test_idf_event() {
 
     e2e_test_wrapper_legacy(
         async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
-            for ts in &test_data {
-                producer
-                    .send_result(
-                        FutureRecord::to(KAFKA_RAW_TOPIC)
-                            .key("")
-                            .payload(&ts.obsinn_ones()),
-                    )
-                    .unwrap()
-                    .await
-                    .unwrap()
-                    .unwrap();
-            }
+            ingest_raw(&test_data, producer, db_pools.clone(), tables).await;
 
+            // HACK: need to set corrected and quality_code to be able to compute idf event
             let open_conn = db_pools.open.get().await.unwrap();
-            let expected_open_rows = ts_len * test_data.len();
-            wait_for_db_readiness(&open_conn, expected_open_rows).await;
-            update_patchwork_table(&open_conn, tables.open).await;
-
-            // HACK: need to set corrected and quality_code
             open_conn
                 .execute(
                     "UPDATE legacy.data SET corrected = 1.0, quality_code = 1",
@@ -698,7 +672,7 @@ async fn test_idf_failure() {
 
     let ts_len = 30;
     let station_id = 10001;
-    let test_data = [
+    let test_data = IngestData::new(vec![
         TestData {
             station_id,
             params: vec![Param::new("RR_01")],
@@ -715,27 +689,11 @@ async fn test_idf_failure() {
             type_id: 508,
             len: ts_len,
         },
-    ];
+    ]);
 
     e2e_test_wrapper_legacy(
         async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
-            for ts in &test_data {
-                producer
-                    .send_result(
-                        FutureRecord::to(KAFKA_RAW_TOPIC)
-                            .key("")
-                            .payload(&ts.obsinn_ones()),
-                    )
-                    .unwrap()
-                    .await
-                    .unwrap()
-                    .unwrap();
-            }
-
-            let open_conn = db_pools.open.get().await.unwrap();
-            let expected_open_rows = ts_len * test_data.len();
-            wait_for_db_readiness(&open_conn, expected_open_rows).await;
-            update_patchwork_table(&open_conn, tables.open).await;
+            ingest_raw(&test_data, producer, db_pools, tables).await;
 
             let url = format!(
                 "http://localhost:3000/reports/idf/event/{station_id}\
@@ -745,7 +703,7 @@ async fn test_idf_failure() {
 
             let resp = reqwest::get(url).await.unwrap();
 
-            // Since the data is not QCed we won't get a positive response
+            // Since the data is not QCed we won't get a positive response (not found error)
             assert!(resp.status().is_client_error(),);
         },
     )

--- a/integration_tests/tests/legacy.rs
+++ b/integration_tests/tests/legacy.rs
@@ -9,7 +9,7 @@ use reqwest::StatusCode;
 use lard_egress::{
     patchwork::PatchworkTables,
     reports::{IdfEvent, IdfEventAvailability, IdfEventResp, DEFAULT_DURATIONS},
-    PatchworkResp,
+    PatchworkAvailableResp, PatchworkResp,
 };
 
 use lard_ingestion::get_conversions;
@@ -302,6 +302,50 @@ async fn test_kafka_raw() {
         assert_eq!(lvl, Some(0));
         assert_eq!(sensor, Some(0));
     })
+    .await
+}
+
+#[tokio::test]
+async fn test_patchwork_available_endpoint() {
+    // We insert a single timeseries so we will only a single label
+    let n_labels = 1;
+
+    e2e_test_wrapper_legacy(
+        async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
+            let data = TestData {
+                station_id: 20001,
+                params: vec![Param::new("TA")],
+                start_time: Utc.with_ymd_and_hms(2024, 12, 15, 0, 0, 0).unwrap(),
+                period: Duration::hours(1),
+                type_id: 508,
+                len: 2,
+            };
+
+            // TODO: maybe all ingestion stuff, until request could be extracted?
+            producer
+                .send_result(
+                    FutureRecord::to(KAFKA_RAW_TOPIC)
+                        .key("")
+                        .payload(&data.obsinn_zeros()),
+                )
+                .unwrap()
+                .await
+                .unwrap()
+                .unwrap();
+
+            let open_conn = db_pools.open.get().await.unwrap();
+            let expected_open_rows = 2;
+            wait_for_db_readiness(&open_conn, expected_open_rows).await;
+            update_patchwork_table(&open_conn, tables.open.clone()).await;
+
+            let url = "http://localhost:3000/patchwork/available";
+            let resp = reqwest::get(url).await.unwrap();
+            assert!(resp.status().is_success());
+
+            let json: PatchworkAvailableResp = resp.json().await.unwrap();
+            assert_eq!(json.available.len(), n_labels);
+        },
+    )
     .await
 }
 

--- a/integration_tests/tests/legacy.rs
+++ b/integration_tests/tests/legacy.rs
@@ -396,6 +396,36 @@ async fn test_patchwork_available_endpoint() {
 }
 
 #[tokio::test]
+async fn test_patchwork_endpoint_failure() {
+    let cases = [
+        // made up param, shouldn't exist
+        "?stationids=10001&params=12345&levels=0&sensors=0&from=2024-12-31T23:00:00Z&to=2025-01-01T01:30:00Z",
+    ];
+
+    e2e_test_wrapper_legacy(
+        async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
+            let data = IngestData::new(vec![TestData {
+                station_id: 10001,
+                params: vec![Param::new("TA")],
+                start_time: Utc.with_ymd_and_hms(2024, 12, 31, 0, 0, 0).unwrap(),
+                period: Duration::hours(1),
+                type_id: 501,
+                len: 48,
+            }]);
+
+            ingest_raw(&data, producer, db_pools, tables).await;
+
+            for query in cases {
+                let url = format!("http://localhost:3000/patchwork{query:?}");
+                let resp = reqwest::get(url).await.unwrap();
+                assert!(resp.status().is_client_error()); // expect 404
+            }
+        },
+    )
+    .await
+}
+
+#[tokio::test]
 async fn test_patchwork_endpoint() {
     // Use values present in the mocks
     let cases = vec![

--- a/integration_tests/tests/legacy.rs
+++ b/integration_tests/tests/legacy.rs
@@ -853,3 +853,104 @@ async fn test_idf_event_restricted() {
     )
     .await
 }
+
+// NOTE: this test will fail if the patches in the patchwork table are not sorted
+#[tokio::test]
+async fn test_idf_event_sorted() {
+    let start_time = Utc.with_ymd_and_hms(2024, 12, 31, 22, 50, 0).unwrap();
+    let priority_shift_time = Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+    let station_id = 10001;
+
+    let test_data = IngestData::new(vec![
+        TestData {
+            station_id,
+            params: vec![Param::new("RR_01")],
+            start_time,
+            period: Duration::minutes(1),
+            type_id: 514,
+            len: 80,
+        },
+        TestData {
+            station_id,
+            params: vec![Param::new("RR_01")],
+            start_time,
+            period: Duration::minutes(1),
+            type_id: 508,
+            len: 80,
+        },
+        TestData {
+            station_id,
+            params: vec![Param::new("RR_01")],
+            start_time,
+            period: Duration::minutes(1),
+            type_id: 501,
+            len: 80,
+        },
+    ]);
+
+    let cases = [(
+        "single duration",
+        priority_shift_time - Duration::minutes(3),
+        priority_shift_time + Duration::minutes(1),
+        "4",
+        vec![IdfEvent::new(
+            // We have three timeseries in three different patches (delimited by |)
+            // | 1 1 1 ... | ... 1 \ 1 1 1 | 2 \ ... |
+            // We are asking data in the interval delimited by \
+            // If the patches are not sorted, the sum accumulation would stop before the first
+            // observation with value 2
+            5.0,
+            4,
+            priority_shift_time - Duration::minutes(3),
+            priority_shift_time,
+        )],
+    )];
+
+    e2e_test_wrapper_legacy(
+        async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
+            ingest_raw(&test_data, producer, db_pools.clone(), tables).await;
+
+            // HACK: need to set corrected and quality_code to be able to compute idf event
+            let conn = db_pools.open.get().await.unwrap();
+            conn.execute(
+                "UPDATE legacy.data SET corrected = 1.0, quality_code = 1 WHERE obstime < $1",
+                &[&priority_shift_time],
+            )
+            .await
+            .unwrap();
+
+            // Set a different value for the second timeseries
+            conn.execute(
+                "UPDATE legacy.data SET corrected = 2.0, quality_code = 1 WHERE obstime >= $1",
+                &[&priority_shift_time],
+            )
+            .await
+            .unwrap();
+
+            for (title, from, to, duration, expected) in cases {
+                let url = format!(
+                    "http://localhost:3000/reports/idf/event/{station_id}\
+                    ?fromtime={from}\
+                    &totime={to}\
+                    &durations={duration}",
+                );
+
+                let resp = Client::new().get(url).send().await.unwrap();
+                assert!(
+                    resp.status().is_success(),
+                    "{title}: {}",
+                    resp.text().await.unwrap()
+                );
+
+                let json: IdfEventResp = resp.json().await.unwrap();
+                assert_eq!(json.station_id, station_id, "{title}");
+                assert_eq!(json.values.len(), expected.len(), "{title}");
+
+                for (val, exp) in json.values.into_iter().zip(expected) {
+                    assert_eq!(val, exp, "{title}")
+                }
+            }
+        },
+    )
+    .await
+}

--- a/integration_tests/tests/legacy.rs
+++ b/integration_tests/tests/legacy.rs
@@ -6,13 +6,19 @@ use rdkafka::producer::{FutureProducer, FutureRecord};
 use reqwest::Client;
 use reqwest::StatusCode;
 
-use lard_egress::PatchworkResp;
+use lard_egress::{
+    patchwork::PatchworkTables,
+    reports::{IdfEvent, IdfEventAvailability, IdfEventResp, DEFAULT_DURATIONS},
+    PatchworkResp,
+};
 
 use lard_ingestion::get_conversions;
-use util::DbPools;
+use util::{DbPools, PooledPgConn};
 
 pub mod common;
 use common::{Param, TestData};
+
+use crate::common::update_patchwork_table;
 
 const KAFKA_RAW_TOPIC: &str = "raw";
 const KAFKA_CHECKED_TOPIC: &str = "checked";
@@ -20,8 +26,10 @@ const KAFKA_CHECKED_HIST_TOPIC: &str = "hist.checked";
 const KAFKA_GROUP: &str = "lard_test";
 
 /// Similar to e2e_test_wrapper, but adapted to use kvkafka ingestion instead of obsinn.
-pub async fn e2e_test_wrapper_legacy(test: impl AsyncFnOnce(FutureProducer, DbPools) -> ()) {
-    let (db_pools, mut egress, cancel_token) = common::wrapper_setup().await;
+pub async fn e2e_test_wrapper_legacy(
+    test: impl AsyncFnOnce(FutureProducer, DbPools, PatchworkTables) -> (),
+) {
+    let (db_pools, patchwork_tables, mut egress, cancel_token) = common::wrapper_setup().await;
 
     let mock_kafka_cluster = rdkafka::mocking::MockCluster::new(3).unwrap();
     mock_kafka_cluster
@@ -59,7 +67,7 @@ pub async fn e2e_test_wrapper_legacy(test: impl AsyncFnOnce(FutureProducer, DbPo
         _ = &mut egress => panic!("API server task terminated first"),
         _ = &mut ingestion => panic!("Ingestor server task terminated first"),
         // Clean up database even if test panics, to avoid test poisoning
-        test_result = AssertUnwindSafe(test(kafka_producer, db_pools.clone())).catch_unwind() => {
+        test_result = AssertUnwindSafe(test(kafka_producer, db_pools.clone(), patchwork_tables.clone())).catch_unwind() => {
             // For debugging a specific test, it might be useful to skip the cleanup process
             #[cfg(not(feature = "debug"))]
             common::db_cleanup(db_pools.clone()).await;
@@ -74,9 +82,27 @@ pub async fn e2e_test_wrapper_legacy(test: impl AsyncFnOnce(FutureProducer, DbPo
     ingestion_result.unwrap().unwrap();
 }
 
+// As we have no way to sync with message processing in kvkafka ingestion, we just keep
+// trying to fetch data with a timeout
+async fn wait_for_db_readiness(conn: &PooledPgConn<'_>, expected_rows: usize) {
+    let timeout = std::time::Duration::from_secs(10);
+    let timeout_start = Instant::now();
+    loop {
+        if let Ok(rows) = conn.query("SELECT timeseries FROM legacy.data", &[]).await {
+            if rows.len() == expected_rows {
+                break;
+            }
+        };
+
+        if timeout_start.elapsed() > timeout {
+            panic!("Timed out waiting for data to appear")
+        }
+    }
+}
+
 #[tokio::test]
 async fn test_kafka_checked() {
-    e2e_test_wrapper_legacy(async |producer: FutureProducer, db_pools: DbPools| {
+    e2e_test_wrapper_legacy(async |producer: FutureProducer, db_pools: DbPools, _| {
         // This observation was 2.5 hours late??
         let kafka_xml = r#"<?xml?>
             <KvalobsData producer=\"kvqabase\" created=\"2024-06-06 08:30:43\">
@@ -112,33 +138,24 @@ async fn test_kafka_checked() {
             .unwrap()
             .unwrap();
 
-        // TODO: we do not have an API endpoint to query the flags.kvdata table
-        let open_conn = db_pools.open.get().await.unwrap();
-
         // As we have no way to sync with message processing in kvkafka ingestion, we just keep
         // trying to fetch data with a timeout
-        let timeout = std::time::Duration::from_secs(10);
-        let timeout_start = Instant::now();
-        loop {
-            if let Ok(data_row) = open_conn
-                .query_one(
-                    r#"
-                        SELECT
-                            timeseries,
-                            obstime,
-                            original,
-                            corrected,
-                            quality_code,
-                            controlinfo,
-                            useinfo,
-                            cfailed
-                        FROM legacy.data
-                    "#,
-                    &[],
-                )
-                .await
-            {
-                #[allow(clippy::type_complexity)]
+        let expected_rows = 1;
+        let open_conn = db_pools.open.get().await.unwrap();
+        wait_for_db_readiness(&open_conn, expected_rows).await;
+
+        // TODO: we do not have an API endpoint to query the flags.kvdata table
+        let data_row = open_conn
+            .query_one(
+                "SELECT timeseries, obstime, original, corrected, \
+                        quality_code, controlinfo, useinfo, cfailed \
+                    FROM legacy.data",
+                &[],
+            )
+            .await
+            .unwrap();
+
+        #[allow(clippy::type_complexity)]
                 let (
                     timeseries,
                     obstime,
@@ -167,77 +184,58 @@ async fn test_kafka_checked() {
                     data_row.get(6),
                     data_row.get(7),
                 );
-                assert_eq!(obstime, Utc.with_ymd_and_hms(2024, 6, 6, 6, 0, 0).unwrap());
-                assert_eq!(original, Some(10.));
-                assert_eq!(corrected, Some(10.));
-                assert_eq!(
-                    quality_code,
-                    lard_ingestion::util::quality_code::get_quality_code(
-                        useinfo.clone().unwrap().as_str()
-                    )
-                );
-                assert_eq!(controlinfo, Some("1000000000000000".to_string()));
-                assert_eq!(useinfo, Some("9000000000000000".to_string()));
-                assert_eq!(cfailed, None);
+        assert_eq!(obstime, Utc.with_ymd_and_hms(2024, 6, 6, 6, 0, 0).unwrap());
+        assert_eq!(original, Some(10.));
+        assert_eq!(corrected, Some(10.));
+        assert_eq!(
+            quality_code,
+            lard_ingestion::util::quality_code::get_quality_code(useinfo.clone().unwrap().as_str())
+        );
+        assert_eq!(controlinfo, Some("1000000000000000".to_string()));
+        assert_eq!(useinfo, Some("9000000000000000".to_string()));
+        assert_eq!(cfailed, None);
 
-                let label_row = open_conn
-                    .query_one(
-                        r#"
-                        SELECT
-                            station_id,
-                            param_id,
-                            type_id,
-                            lvl,
-                            sensor
-                        FROM labels.kvalobs
-                        WHERE timeseries = $1
-                    "#,
-                        &[&timeseries],
-                    )
-                    .await
-                    .unwrap();
+        let label_row = open_conn
+            .query_one(
+                "SELECT  station_id, param_id, type_id, lvl, sensor \
+                    FROM labels.kvalobs \
+                    WHERE timeseries = $1",
+                &[&timeseries],
+            )
+            .await
+            .unwrap();
 
-                #[allow(clippy::type_complexity)]
-                let (station_id, param_id, type_id, lvl, sensor): (
-                    // should these really all be Option??
-                    Option<i32>,
-                    Option<i32>,
-                    Option<i32>,
-                    Option<i32>,
-                    Option<i32>,
-                ) = (
-                    label_row.get(0),
-                    label_row.get(1),
-                    label_row.get(2),
-                    label_row.get(3),
-                    label_row.get(4),
-                );
+        #[allow(clippy::type_complexity)]
+        let (station_id, param_id, type_id, lvl, sensor): (
+            // should these really all be Option??
+            Option<i32>,
+            Option<i32>,
+            Option<i32>,
+            Option<i32>,
+            Option<i32>,
+        ) = (
+            label_row.get(0),
+            label_row.get(1),
+            label_row.get(2),
+            label_row.get(3),
+            label_row.get(4),
+        );
 
-                assert_eq!(station_id, Some(20001));
-                assert_eq!(param_id, Some(106));
-                assert_eq!(type_id, Some(-4));
-                assert_eq!(lvl, Some(0));
-                assert_eq!(sensor, Some(0));
-
-                break;
-            }
-
-            if timeout_start.elapsed() > timeout {
-                panic!("Timed out waiting for data to appear")
-            }
-        }
+        assert_eq!(station_id, Some(20001));
+        assert_eq!(param_id, Some(106));
+        assert_eq!(type_id, Some(-4));
+        assert_eq!(lvl, Some(0));
+        assert_eq!(sensor, Some(0));
     })
     .await
 }
 
 #[tokio::test]
 async fn test_kafka_raw() {
-    e2e_test_wrapper_legacy(async |producer: FutureProducer, db_pools: DbPools| {
+    e2e_test_wrapper_legacy(async |producer: FutureProducer, db_pools: DbPools, _| {
         let ts = TestData {
             station_id: 20001,
             params: vec![Param::new("TA")],
-            // start_time: Utc::now().duration_trunc(TimeDelta::hours(1)).unwrap()
-            //     - Duration::hours(11),
             start_time: Utc.with_ymd_and_hms(2024, 6, 6, 6, 0, 0).unwrap(),
             period: Duration::hours(1),
             type_id: 501,
@@ -248,115 +246,110 @@ async fn test_kafka_raw() {
             .send_result(
                 FutureRecord::to(KAFKA_RAW_TOPIC)
                     .key("")
-                    .payload(&ts.obsinn_message()),
+                    .payload(&ts.obsinn_zeros()),
             )
             .unwrap()
             .await
             .unwrap()
             .unwrap();
 
-        // TODO: we do not have an API endpoint to query the flags.kvdata table
-        let open_conn = db_pools.open.get().await.unwrap();
-
         // As we have no way to sync with message processing in kvkafka ingestion, we just keep
         // trying to fetch data with a timeout
-        let timeout = std::time::Duration::from_secs(10);
-        let timeout_start = Instant::now();
-        loop {
-            if let Ok(data_row) = open_conn
-                .query_one(
-                    r#"
-                        SELECT
-                            timeseries,
-                            obstime,
-                            original
-                        FROM legacy.data
-                    "#,
-                    &[],
-                )
-                .await
-            {
-                let (timeseries, obstime, original): (i64, DateTime<Utc>, Option<f64>) =
-                    (data_row.get(0), data_row.get(1), data_row.get(2));
-                assert_eq!(obstime, Utc.with_ymd_and_hms(2024, 6, 6, 6, 0, 0).unwrap());
-                assert_eq!(original, Some(0.));
+        let expected_rows = 1;
+        let open_conn = db_pools.open.get().await.unwrap();
+        wait_for_db_readiness(&open_conn, expected_rows).await;
 
-                let label_row = open_conn
-                    .query_one(
-                        r#"
-                        SELECT
-                            station_id,
-                            param_id,
-                            type_id,
-                            lvl,
-                            sensor
-                        FROM labels.kvalobs
-                        WHERE timeseries = $1
-                    "#,
-                        &[&timeseries],
-                    )
-                    .await
-                    .unwrap();
+        // TODO: we do not have an API endpoint to query the flags.kvdata table
+        let data_row = open_conn
+            .query_one("SELECT timeseries, obstime, original FROM legacy.data", &[])
+            .await
+            .unwrap();
 
-                #[allow(clippy::type_complexity)]
-                let (station_id, param_id, type_id, lvl, sensor): (
-                    // should these really all be Option??
-                    Option<i32>,
-                    Option<i32>,
-                    Option<i32>,
-                    Option<i32>,
-                    Option<i32>,
-                ) = (
-                    label_row.get(0),
-                    label_row.get(1),
-                    label_row.get(2),
-                    label_row.get(3),
-                    label_row.get(4),
-                );
+        let (timeseries, obstime, original): (i64, DateTime<Utc>, Option<f64>) =
+            (data_row.get(0), data_row.get(1), data_row.get(2));
+        assert_eq!(obstime, Utc.with_ymd_and_hms(2024, 6, 6, 6, 0, 0).unwrap());
+        assert_eq!(original, Some(0.));
 
-                assert_eq!(station_id, Some(20001));
-                assert_eq!(param_id, Some(211));
-                assert_eq!(type_id, Some(501));
-                assert_eq!(lvl, Some(0));
-                assert_eq!(sensor, Some(0));
+        let label_row = open_conn
+            .query_one(
+                "SELECT station_id, param_id, type_id, lvl, sensor \
+                        FROM labels.kvalobs \
+                        WHERE timeseries = $1",
+                &[&timeseries],
+            )
+            .await
+            .unwrap();
 
-                break;
-            }
+        #[allow(clippy::type_complexity)]
+        let (station_id, param_id, type_id, lvl, sensor): (
+            // should these really all be Option??
+            Option<i32>,
+            Option<i32>,
+            Option<i32>,
+            Option<i32>,
+            Option<i32>,
+        ) = (
+            label_row.get(0),
+            label_row.get(1),
+            label_row.get(2),
+            label_row.get(3),
+            label_row.get(4),
+        );
 
-            if timeout_start.elapsed() > timeout {
-                panic!("Timed out waiting for data to appear")
-            }
-        }
+        assert_eq!(station_id, Some(20001));
+        assert_eq!(param_id, Some(211));
+        assert_eq!(type_id, Some(501));
+        assert_eq!(lvl, Some(0));
+        assert_eq!(sensor, Some(0));
     })
     .await
 }
 
-// test patchwork...
 #[tokio::test]
 async fn test_patchwork_endpoint() {
-    // find an example from the mock table...
+    // Use values present in the mocks
     let cases = vec![
         (
-            "?stationids=10001&paramids=211&levels=0&sensors=0&from=2024-12-31T23:00:00Z&to=2025-01-01T01:30:00Z",
+            "?stationids=10001\
+            &paramids=211\
+            &levels=200\
+            &sensors=0\
+            &from=2024-12-31T23:00:00Z\
+            &to=2025-01-01T01:30:00Z",
             None,
             200,
             3,
         ),
         (
-            "?stationids=10001,20001&paramids=211,225&levels=0&sensors=0&from=2024-12-31T23:00:00Z&to=2025-01-01T01:30:00Z",
+            "?stationids=10001,20001\
+            &paramids=211,225\
+            &levels=200\
+            &sensors=0\
+            &from=2024-12-31T23:00:00Z\
+            &to=2025-01-01T01:30:00Z",
             None,
             200,
             3,
         ),
         // 99995 has permitid 5 in mock_permit_tables(), so is restricted
         (
-            "?stationids=99995&paramids=211&levels=0&sensors=0&from=2024-12-31T23:00:00Z&to=2025-01-01T01:30:00Z",
+            "?stationids=99995\
+            &paramids=211\
+            &levels=200\
+            &sensors=0\
+            &from=2024-12-31T23:00:00Z\
+            &to=2025-01-01T01:30:00Z",
             None, // no token, no data access
             404, // just don't see it... 
             0,
         ),
         (
-            "?stationids=99995&paramids=211&levels=0&sensors=0&from=2024-12-31T23:00:00Z&to=2025-01-01T01:30:00Z",
+            "?stationids=99995\
+            &paramids=211\
+            &levels=200\
+            &sensors=0\
+            &from=2024-12-31T23:00:00Z\
+            &to=2025-01-01T01:30:00Z",
             // fake token created with roles 9,5 so should be able to see data
             Some("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCJ9.eyJyZXNvdXJjZV9hY2Nlc3MiOnsiT0RBIjp7InJvbGVzIjpbInBlcm1pdGlkLTkiLCJwZXJtaXRpZC01Il19fSwiZXhwIjoyMDcxOTE2MTY2fQ.K9VSyzl583Ck5pAvWj1dBHZ57VPeG00XyZY686BCLEtpCXAgB2I1FunROt3Vl1sP2mohnhbb5GOZInx_y-RW1LBHEeZRK-expKC10ipYsqUbG8-P0fw8HFH7vedMExHO"),
             200,
@@ -364,130 +357,353 @@ async fn test_patchwork_endpoint() {
         ),
     ];
 
-    e2e_test_wrapper_legacy(async |producer: FutureProducer, db_pools: DbPools| {
-        let t1: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 12, 31, 20, 0, 0).unwrap();
-        let test_data = [
-            TestData {
-                station_id: 10001,
-                params: vec![Param::new("TA")],
-                start_time: t1,
-                period: Duration::hours(1),
-                type_id: 508,
-                len: 8,
-            },
-            TestData {
-                station_id: 10001,
-                params: vec![Param::new("TA")],
-                start_time: t1,
-                period: Duration::hours(1),
-                type_id: 501,
-                len: 8,
-            },
-            TestData {
-                station_id: 20001,
-                params: vec![Param::new("TGX")],
-                start_time: t1,
-                period: Duration::hours(1),
-                type_id: 501,
-                len: 8,
-            },
-            TestData {
-                station_id: 99995,
-                params: vec![Param::new("TA")],
-                start_time: t1,
-                period: Duration::hours(1),
-                type_id: 508,
-                len: 8,
-            },
-            TestData {
-                station_id: 99995,
-                params: vec![Param::new("TA")],
-                start_time: t1,
-                period: Duration::hours(1),
-                type_id: 501,
-                len: 8,
-            },
-        ];
+    e2e_test_wrapper_legacy(
+        async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
+            let t1: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 12, 31, 20, 0, 0).unwrap();
+            let test_data = [
+                TestData {
+                    station_id: 10001,
+                    params: vec![Param::new("TA")],
+                    start_time: t1,
+                    period: Duration::hours(1),
+                    type_id: 508,
+                    len: 8,
+                },
+                TestData {
+                    station_id: 10001,
+                    params: vec![Param::new("TA")],
+                    start_time: t1,
+                    period: Duration::hours(1),
+                    type_id: 501,
+                    len: 8,
+                },
+                TestData {
+                    station_id: 20001,
+                    params: vec![Param::new("TGX")],
+                    start_time: t1,
+                    period: Duration::hours(1),
+                    type_id: 501,
+                    len: 8,
+                },
+                TestData {
+                    station_id: 99995,
+                    params: vec![Param::new("TA")],
+                    start_time: t1,
+                    period: Duration::hours(1),
+                    type_id: 508,
+                    len: 8,
+                },
+                TestData {
+                    station_id: 99995,
+                    params: vec![Param::new("TA")],
+                    start_time: t1,
+                    period: Duration::hours(1),
+                    type_id: 501,
+                    len: 8,
+                },
+            ];
 
-        for ts in test_data {
-            producer
-                .send_result(
-                    FutureRecord::to(KAFKA_RAW_TOPIC)
-                        .key("")
-                        .payload(&ts.obsinn_message()),
-                )
-                .unwrap()
-                .await
-                .unwrap()
-                .unwrap();
-        }
+            for ts in test_data {
+                producer
+                    .send_result(
+                        FutureRecord::to(KAFKA_RAW_TOPIC)
+                            .key("")
+                            .payload(&ts.obsinn_zeros()),
+                    )
+                    .unwrap()
+                    .await
+                    .unwrap()
+                    .unwrap();
+            }
 
-        let open_conn = db_pools.open.get().await.unwrap();
-        let restricted_conn = db_pools.restricted.get().await.unwrap();
+            let open_conn = db_pools.open.get().await.unwrap();
+            let restricted_conn = db_pools.restricted.get().await.unwrap();
 
-        // As we have no way to sync with message processing in kvkafka ingestion, we just keep
-        // trying to fetch data with a timeout
-        let timeout = std::time::Duration::from_secs(10);
-        let timeout_start = Instant::now();
-        loop {
-            if let Ok(data_rows) = open_conn
-                .query(
-                    r#"
-                        SELECT
-                            timeseries,
-                            obstime,
-                            original
-                        FROM legacy.data
-                    "#,
-                    &[],
-                )
-                .await
-            {
-                if data_rows.len() == 24 {
-                    // have the open data, but also check restricted
-                    if let Ok(data_rows_restricted) = restricted_conn
-                        .query(
-                            r#"
-                        SELECT
-                            timeseries,
-                            obstime,
-                            original
-                        FROM legacy.data
-                    "#,
-                            &[],
-                        )
-                        .await
-                    {
-                        if data_rows_restricted.len() == 16 {
-                            break;
-                        }
+            let expected_open_rows = 24;
+            let expected_restricted_rows = 16;
+            tokio::join!(
+                wait_for_db_readiness(&open_conn, expected_open_rows),
+                wait_for_db_readiness(&restricted_conn, expected_restricted_rows),
+            );
+
+            // Update patchwork with the timeseries in the database
+            update_patchwork_table(&open_conn, tables.open.clone()).await;
+
+            for (query, token, status, n_data_found) in cases {
+                let url = format!("http://localhost:3000/patchwork{query}");
+                let client = Client::new();
+                let request = match token {
+                    Some(t) => client.get(url).bearer_auth(t),
+                    None => client.get(url),
+                };
+
+                let resp = request.send().await.unwrap();
+                assert!(resp.status() == status);
+
+                if status == StatusCode::OK {
+                    let json: Vec<PatchworkResp> = resp.json().await.unwrap();
+                    for x in json {
+                        assert_eq!(x.data.len(), n_data_found);
                     }
                 }
             }
-            // or else keep looping since no data has been written
+        },
+    )
+    .await
+}
 
-            if timeout_start.elapsed() > timeout {
-                panic!("Timed out waiting for data to appear")
+#[tokio::test]
+async fn test_idf_event_availability() {
+    e2e_test_wrapper_legacy(
+        async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
+            let start_time = Utc.with_ymd_and_hms(2024, 12, 31, 23, 50, 0).unwrap();
+            let ts_len = 20;
+            let test_data = [
+                TestData {
+                    station_id: 10001,
+                    params: vec![Param::new("RR_01")],
+                    start_time,
+                    period: Duration::minutes(1),
+                    type_id: 514,
+                    len: ts_len,
+                },
+                TestData {
+                    station_id: 20001,
+                    params: vec![Param::new("RR_01")],
+                    start_time,
+                    period: Duration::minutes(1),
+                    type_id: 508,
+                    len: ts_len,
+                },
+            ];
+
+            for ts in &test_data {
+                producer
+                    .send_result(
+                        FutureRecord::to(KAFKA_RAW_TOPIC)
+                            .key("")
+                            .payload(&ts.obsinn_zeros()),
+                    )
+                    .unwrap()
+                    .await
+                    .unwrap()
+                    .unwrap();
             }
-        }
-        for (query, token, status, n_data_found) in cases {
-            let url = format!("http://localhost:3000/patchwork{query}");
-            let client = Client::new();
-            let request = match token {
-                Some(t) => client.get(url).bearer_auth(t),
-                None => client.get(url),
-            };
 
-            let resp = request.send().await.unwrap();
-            assert!(resp.status() == status);
+            let open_conn = db_pools.open.get().await.unwrap();
+            let expected_open_rows = ts_len * test_data.len();
+            wait_for_db_readiness(&open_conn, expected_open_rows).await;
 
-            if status == StatusCode::OK {
-                let json: Vec<PatchworkResp> = resp.json().await.unwrap();
-                for x in json {
-                    assert_eq!(x.data.len(), n_data_found);
+            update_patchwork_table(&open_conn, tables.open).await;
+
+            let url = "http://localhost:3000/reports/idf/event";
+            let resp = reqwest::get(url).await.unwrap();
+            assert!(resp.status().is_success(), "{}", resp.text().await.unwrap());
+
+            let json: IdfEventAvailability = resp.json().await.unwrap();
+            assert_eq!(json.stations.len(), test_data.len(), "{json:?}");
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_idf_event() {
+    let start_time = Utc.with_ymd_and_hms(2024, 12, 31, 23, 40, 0).unwrap();
+    let end_first_ts = Utc.with_ymd_and_hms(2024, 12, 31, 23, 49, 0).unwrap();
+    let end_second_ts = Utc.with_ymd_and_hms(2025, 1, 1, 0, 9, 0).unwrap();
+
+    let ts_len = 30;
+    let station_id = 10001;
+    let test_data = [
+        TestData {
+            station_id,
+            params: vec![Param::new("RR_01")],
+            start_time,
+            period: Duration::minutes(1),
+            type_id: 514,
+            len: ts_len,
+        },
+        TestData {
+            station_id,
+            params: vec![Param::new("RR_01")],
+            start_time,
+            period: Duration::minutes(1),
+            type_id: 508,
+            len: ts_len,
+        },
+    ];
+
+    let default_end_time = start_time.checked_add_signed(Duration::minutes(1)).unwrap();
+    let cases = [
+        (
+            // Only extract 2 observations for simplicity (painful)
+            "default durations",
+            start_time,
+            start_time.checked_add_signed(Duration::minutes(2)).unwrap(),
+            None,
+            DEFAULT_DURATIONS
+                .iter()
+                .map(|d| {
+                    let (intensity, end_time) = if *d == 1 {
+                        (1.0, start_time)
+                    } else {
+                        (2.0, default_end_time)
+                    };
+                    IdfEvent::new(intensity, *d, start_time, end_time)
+                })
+                .collect(),
+        ),
+        (
+            // Should only get the first timeseries
+            "single duration",
+            start_time,
+            start_time
+                .checked_add_signed(Duration::minutes(10))
+                .unwrap(),
+            Some(vec![10]),
+            vec![IdfEvent::new(10.0, 10, start_time, end_first_ts)],
+        ),
+        (
+            // Should get both timeseries
+            "multiple durations",
+            start_time,
+            start_time
+                .checked_add_signed(Duration::minutes(50))
+                .unwrap(),
+            Some(vec![10, 40]),
+            vec![
+                IdfEvent::new(10.0, 10, start_time, end_first_ts),
+                IdfEvent::new(30.0, 40, start_time, end_second_ts),
+            ],
+        ),
+    ];
+
+    e2e_test_wrapper_legacy(
+        async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
+            for ts in &test_data {
+                producer
+                    .send_result(
+                        FutureRecord::to(KAFKA_RAW_TOPIC)
+                            .key("")
+                            .payload(&ts.obsinn_ones()),
+                    )
+                    .unwrap()
+                    .await
+                    .unwrap()
+                    .unwrap();
+            }
+
+            let open_conn = db_pools.open.get().await.unwrap();
+            let expected_open_rows = ts_len * test_data.len();
+            wait_for_db_readiness(&open_conn, expected_open_rows).await;
+            update_patchwork_table(&open_conn, tables.open).await;
+
+            // HACK: need to set corrected and quality_code
+            open_conn
+                .execute(
+                    "UPDATE legacy.data SET corrected = 1.0, quality_code = 1",
+                    &[],
+                )
+                .await
+                .unwrap();
+
+            for (title, from, to, durations, expected) in cases {
+                let duration_query = durations
+                    .map(|v| {
+                        let joined = v
+                            .iter()
+                            .map(|d| d.to_string())
+                            .collect::<Vec<_>>()
+                            .join(",");
+                        format!("&durations={joined}")
+                    })
+                    .unwrap_or("".to_string());
+
+                let url = format!(
+                    "http://localhost:3000/reports/idf/event/{station_id}\
+                        ?fromtime={from}\
+                        &totime={to}\
+                        {duration_query}",
+                );
+
+                let resp = reqwest::get(url).await.unwrap();
+                assert!(
+                    resp.status().is_success(),
+                    "{title}: {}",
+                    resp.text().await.unwrap()
+                );
+
+                let json: IdfEventResp = resp.json().await.unwrap();
+                assert_eq!(json.station_id, station_id, "{title}");
+                assert_eq!(json.values.len(), expected.len(), "{title}");
+
+                for (val, exp) in json.values.into_iter().zip(expected) {
+                    assert_eq!(val, exp, "{title}")
                 }
             }
-        }
-    })
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_idf_failure() {
+    let start_time = Utc.with_ymd_and_hms(2024, 12, 31, 23, 40, 0).unwrap();
+    let end_time = Utc.with_ymd_and_hms(2025, 1, 1, 0, 9, 0).unwrap();
+
+    let ts_len = 30;
+    let station_id = 10001;
+    let test_data = [
+        TestData {
+            station_id,
+            params: vec![Param::new("RR_01")],
+            start_time,
+            period: Duration::minutes(1),
+            type_id: 514,
+            len: ts_len,
+        },
+        TestData {
+            station_id,
+            params: vec![Param::new("RR_01")],
+            start_time,
+            period: Duration::minutes(1),
+            type_id: 508,
+            len: ts_len,
+        },
+    ];
+
+    e2e_test_wrapper_legacy(
+        async |producer: FutureProducer, db_pools: DbPools, tables: PatchworkTables| {
+            for ts in &test_data {
+                producer
+                    .send_result(
+                        FutureRecord::to(KAFKA_RAW_TOPIC)
+                            .key("")
+                            .payload(&ts.obsinn_ones()),
+                    )
+                    .unwrap()
+                    .await
+                    .unwrap()
+                    .unwrap();
+            }
+
+            let open_conn = db_pools.open.get().await.unwrap();
+            let expected_open_rows = ts_len * test_data.len();
+            wait_for_db_readiness(&open_conn, expected_open_rows).await;
+            update_patchwork_table(&open_conn, tables.open).await;
+
+            let url = format!(
+                "http://localhost:3000/reports/idf/event/{station_id}\
+                        ?fromtime={start_time}\
+                        &totime={end_time}"
+            );
+
+            let resp = reqwest::get(url).await.unwrap();
+
+            // Since the data is not QCed we won't get a positive response
+            assert!(resp.status().is_client_error(),);
+        },
+    )
     .await
 }

--- a/justfile
+++ b/justfile
@@ -36,7 +36,7 @@ _go_test:
 
 [doc("Run the specified Rust e2e test")]
 test name: _setup
-    cargo test {{name}} -p lard_tests --features debug --no-fail-fast -- --nocapture --test-threads=1
+    cargo test {{name}} -p lard_tests --features debug --no-fail-fast -- --nocapture --test-threads=1 --exact
 
 [doc("psql into the container database")]
 psql db="lard":

--- a/util/src/deserialize.rs
+++ b/util/src/deserialize.rs
@@ -1,0 +1,62 @@
+//! Here we define various functions that can be used with `#[serde(deserialize_with = "")]`
+use std::{fmt, marker::PhantomData, str::FromStr};
+
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer,
+};
+
+// TODO: could use serde_with but it seems a bit annoying since it introduces new macros/syntax
+// Deserialize a comma separated list of strings
+// Adapted from https://github.com/serde-rs/serde/issues/581#issuecomment-253626616
+pub fn comma_separated<'de, D, V, T>(des: D) -> Result<V, D::Error>
+where
+    V: FromIterator<T>,
+    D: Deserializer<'de>,
+    T: FromStr,
+    <T as FromStr>::Err: fmt::Display,
+{
+    struct CommaSeparated<V, T>(PhantomData<V>, PhantomData<T>);
+
+    impl<'de, V, T> Visitor<'de> for CommaSeparated<V, T>
+    where
+        V: FromIterator<T>,
+        T: FromStr,
+        <T as FromStr>::Err: fmt::Display,
+    {
+        type Value = V;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string containing comma-separated elements")
+        }
+
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let iter = s.split(",").map(|val| val.parse::<T>());
+            Result::from_iter(iter).map_err(de::Error::custom)
+        }
+    }
+
+    let visitor = CommaSeparated(PhantomData, PhantomData);
+    des.deserialize_str(visitor)
+}
+
+pub fn optional_comma_separated<'de, D, T>(des: D) -> Result<Option<Vec<T>>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: FromStr,
+    <T as FromStr>::Err: fmt::Display,
+{
+    let parsed = match Option::<&str>::deserialize(des)? {
+        Some(s) => {
+            let iter = s.split(",").map(|val| val.parse::<T>());
+            let res = Result::from_iter(iter).map_err(de::Error::custom)?;
+            Some(res)
+        }
+        None => None,
+    };
+
+    Ok(parsed)
+}

--- a/util/src/deserialize.rs
+++ b/util/src/deserialize.rs
@@ -6,8 +6,7 @@ use serde::{
     Deserialize, Deserializer,
 };
 
-// TODO: could use serde_with but it seems a bit annoying since it introduces new macros/syntax
-// Deserialize a comma separated list of strings
+// Deserialize a comma separated list of strings to a collection of the requested type
 // Adapted from https://github.com/serde-rs/serde/issues/581#issuecomment-253626616
 pub fn comma_separated<'de, D, V, T>(des: D) -> Result<V, D::Error>
 where

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -6,6 +6,8 @@ use tokio::signal::unix::{signal, SignalKind};
 use tokio_postgres::{types::FromSql, NoTls};
 use tokio_util::sync::CancellationToken;
 
+pub mod deserialize;
+
 pub type PooledPgConn<'a> = PooledConnection<'a, PostgresConnectionManager<NoTls>>;
 pub type PgPool = bb8::Pool<PostgresConnectionManager<NoTls>>;
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -7,12 +7,12 @@ use tokio_postgres::{types::FromSql, NoTls};
 use tokio_util::sync::CancellationToken;
 
 pub type PooledPgConn<'a> = PooledConnection<'a, PostgresConnectionManager<NoTls>>;
-pub type PgConnectionPool = bb8::Pool<PostgresConnectionManager<NoTls>>;
+pub type PgPool = bb8::Pool<PostgresConnectionManager<NoTls>>;
 
 #[derive(Debug, Clone)]
 pub struct DbPools {
-    pub open: PgConnectionPool,
-    pub restricted: PgConnectionPool,
+    pub open: PgPool,
+    pub restricted: PgPool,
 }
 
 #[derive(Debug, Serialize, Deserialize, FromSql)]


### PR DESCRIPTION
I have left a lot of TODOs since I'm not 100% sure what we are supposed to do.
The main blockers for this to be merged are:
1. in ODA the filter timeseries is used to compute this report.
2. ~~We should move away from PT1M observations (which include approximate manual observations) to instead only use hourly automatic observations.~~