### PR TITLE
ingestion/legacy/checked: downgrade missing sensor to warning

### DIFF
--- a/ingestion/src/legacy/checked.rs
+++ b/ingestion/src/legacy/checked.rs
@@ -103,24 +103,28 @@ fn parse_message(xmlmsg: &str) -> Result<Vec<UnlabelledDatum>, Error> {
                     // it's the first time it entered the db in kvalobs. Currently not using it
                     // TODO: Do we want to handle text data at all? It doesn't seem to be QCed
                     // if let Some(textdata) = tbtime.kvtextdata {...}
-                    for sensor in tbtime.sensors {
-                        for level in sensor.levels {
-                            if let Some(kvdata) = level.kvdata {
-                                for kvdatum in kvdata {
-                                    data.push(UnlabelledDatum {
-                                        kvid: KvalobsId {
-                                            station: station.val,
-                                            param: Param::Id(kvdatum.paramid),
-                                            typeid: typeid.val,
-                                            sensor: sensor.val.unwrap_or(0),
-                                            level: level.val.unwrap_or(0),
-                                        },
-                                        obstime: obs_time,
-                                        value: kvdatum,
-                                    });
+                    if let Some(sensors) = tbtime.sensors {
+                        for sensor in sensors {
+                            for level in sensor.levels {
+                                if let Some(kvdata) = level.kvdata {
+                                    for kvdatum in kvdata {
+                                        data.push(UnlabelledDatum {
+                                            kvid: KvalobsId {
+                                                station: station.val,
+                                                param: Param::Id(kvdatum.paramid),
+                                                typeid: typeid.val,
+                                                sensor: sensor.val.unwrap_or(0),
+                                                level: level.val.unwrap_or(0),
+                                            },
+                                            obstime: obs_time,
+                                            value: kvdatum,
+                                        });
+                                    }
                                 }
                             }
                         }
+                    } else {
+                        warn!("malformed xml message, missing sensor: {xmlmsg}")
                     }
                 }
             }

--- a/ingestion/src/util/xml_types.rs
+++ b/ingestion/src/util/xml_types.rs
@@ -37,7 +37,7 @@ pub struct Tbtime {
     _val: String, // avoiding parsing time at this point...
     _kvtextdata: Option<Vec<Kvtextdata>>,
     #[serde(rename = "sensor")]
-    pub sensors: Vec<Sensor>,
+    pub sensors: Option<Vec<Sensor>>,
 }
 /// Represents <kvtextdata>...</kvtextdata>
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Kvalobs sends a lot of these (~2 per day) and they seem malformed. I don't want to get an alert for every one of these, So I've modified the parser to permit them and emit a warning instead. I've also asked in the kvalobs-drift chat if they have some other recommendation for handling these.