### PR TITLE
ansible: add postgres dependency to systemd services

### DIFF
--- a/ansible/roles/deploy/files/lard_egress.service
+++ b/ansible/roles/deploy/files/lard_egress.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=lard egress service
+Requires=postgresql@17-main.service
 
 [Service]
 User=lard

--- a/ansible/roles/deploy/files/lard_ingestion.service
+++ b/ansible/roles/deploy/files/lard_ingestion.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=lard ingestion service
+Requires=postgresql@17-main.service
 
 [Service]
 User=lard


### PR DESCRIPTION
Resolves an issue we were seeing in the wild where postgres would restart randomly, and break the connections in ingestion. This triggers ingestion (and egress) to stop when postgres stops, and restart when postgres restarts, if they are running.