### PR TITLE
avoid bug where fail when trying to parse nulls

### DIFF
--- a/egress/src/patchwork.rs
+++ b/egress/src/patchwork.rs
@@ -146,8 +146,8 @@ impl PriorityStruct {
 pub struct PatchworkDatum {
     // can assume have original and timestamp? (the field for original value
     // can technically be null (database schema wise)...)
-    // but do not always have corrected and quality code
-    original: f64,
+    // definitely do not always have corrected and quality code (eg. before qc'ing)
+    original: Option<f64>,
     timestamp: DateTime<Utc>,
     corrected: Option<f64>,
     quality_code: Option<i32>,
@@ -677,7 +677,6 @@ pub async fn get_patchwork(
             WHERE timeseries = $1 \
                 AND obstime >= $2 \
                 AND obstime < $3 \
-            AND original IS NOT NULL \
             ORDER BY obstime",
         )
         .await?;


### PR DESCRIPTION
```
Oct 31 11:24:46 lard-b1 lard_egress[225014]: thread 'tokio-runtime-worker' panicked at /home/louiseo/Documents/gitlab.met.no/lard/egress/src/patchwork.rs:706:28:
Oct 31 11:24:46 lard-b1 lard_egress[225014]: error retrieving column 2: error deserializing column 2: a Postgres value was `NULL`
```
triggered with this call: http://xxxx:3000/patchwork?stationids=17810&paramids=329&levels=200&sensors=0&from=2025-09-01T00:00:00Z&to=2025-10-31T00:00:00Z

Seems pluviometer data is sending nulls... 
