### PR TITLE
add frequency and duration summaries to idf available

### DIFF
--- a/egress/src/reports/idf_station.rs
+++ b/egress/src/reports/idf_station.rs
@@ -138,18 +138,14 @@ pub fn parse_metadata_csv(bytes: &[u8]) -> Result<Vec<IdfMetadataAvailability>, 
 
         // Bring the vectors back from strings
         // (currently the csv writer doesn't support this? nor does it support nested structs)
-        let parsed_durations: Vec<u32> = record
-            .durations
+        let parsed_durations_frequencies: Vec<(u32, i32)> = record
+            .durations_frequencies
             .trim_matches(|c| c == '[' || c == ']') // Remove brackets if present
             .split(',')
-            .filter_map(|s| s.trim().parse().ok()) // Parse each element
-            .collect();
-
-        let parsed_frequencies: Vec<i32> = record
-            .frequencies
-            .trim_matches(|c| c == '[' || c == ']') // Remove brackets if present
-            .split(',')
-            .filter_map(|s| s.trim().parse().ok()) // Parse each element
+            .filter_map(|pair| {
+                pair.split_once("|")
+                    .map(|f| (f.0.parse().ok().unwrap(), f.1.parse().ok().unwrap()))
+            })
             .collect();
 
         metadata.push(IdfMetadataAvailability {
@@ -160,8 +156,7 @@ pub fn parse_metadata_csv(bytes: &[u8]) -> Result<Vec<IdfMetadataAvailability>, 
             quality_class: record.quality_class,
             seed_parameter: record.seed_parameter,
             updated_at: record.updated_at,
-            durations: parsed_durations,
-            frequencies: parsed_frequencies,
+            durations_frequencies: parsed_durations_frequencies,
         });
     });
     Ok(metadata)
@@ -200,8 +195,7 @@ mod tests {
             quality_class: 3,
             seed_parameter: 0,
             updated_at: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
-            durations: "1,2".to_string(),
-            frequencies: "1,2".to_string(),
+            durations_frequencies: "[(1,1),(2,2)]".to_string(),
         };
 
         let expected_values = [
@@ -286,8 +280,7 @@ mod tests {
                 quality_class: 3,
                 seed_parameter: 0,
                 updated_at: NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
-                durations: vec![1, 2],
-                frequencies: vec![1, 2],
+                durations_frequencies: vec![(1, 1), (2, 2)],
             },
             IdfMetadataAvailability {
                 station_id: 67890,
@@ -297,8 +290,7 @@ mod tests {
                 quality_class: 0,
                 seed_parameter: 0,
                 updated_at: NaiveDate::from_ymd_opt(2010, 1, 1).unwrap(),
-                durations: vec![1, 2],
-                frequencies: vec![1, 2],
+                durations_frequencies: vec![(1, 1), (2, 2)],
             },
         ];
 
@@ -307,7 +299,7 @@ mod tests {
             for meta in &expected_stations {
                 writeln!(
                     &mut csv,
-                    "{},{},{},{},{},{},{},{:?},{:?}\n",
+                    "{},{},{},{},{},{},{},{:?}\n",
                     meta.station_id,
                     meta.number_of_seasons,
                     meta.from_time,
@@ -315,8 +307,7 @@ mod tests {
                     meta.quality_class,
                     meta.seed_parameter,
                     meta.updated_at,
-                    "[1,2]",
-                    "[1,2]"
+                    "[1|1,2|2]",
                 )
                 .unwrap()
             }

--- a/integration_tests/tests/idf_station.rs
+++ b/integration_tests/tests/idf_station.rs
@@ -14,8 +14,8 @@ async fn test_idf_station_availability() {
     let file = (
         IDF_S3_PATH,
         "metadata.csv",
-        "12345,39,1968-01-01,2023-01-01,3,0,2024-01-01,\"[1,2]\",\"[1,2]\"
-67890,50,1999-01-01,2009-01-01,0,0,2010-01-01,\"[1,2]\",\"[1,2]\"",
+        "12345,39,1968-01-01,2023-01-01,3,0,2024-01-01,\"[1|1,2|2]\"
+67890,50,1999-01-01,2009-01-01,0,0,2010-01-01,\"[1|1,2|2]\"",
     );
     s3_test_wrapper(file, async || {
         let url = "http://localhost:3000/reports/idf/station";
@@ -29,8 +29,7 @@ async fn test_idf_station_availability() {
                     3,
                     0,
                     NaiveDate::from_ymd_opt(2024, 1, 1).unwrap(),
-                    vec![1, 2],
-                    vec![1, 2],
+                    vec![(1, 1), (2, 2)],
                 ),
                 IdfMetadataAvailability::new(
                     67890,
@@ -40,8 +39,7 @@ async fn test_idf_station_availability() {
                     0,
                     0,
                     NaiveDate::from_ymd_opt(2010, 1, 1).unwrap(),
-                    vec![1, 2],
-                    vec![1, 2],
+                    vec![(1, 1), (2, 2)],
                 ),
             ],
         };

--- a/util/src/idf_parse.rs
+++ b/util/src/idf_parse.rs
@@ -137,8 +137,7 @@ pub struct IdfMetadataOutput {
     pub quality_class: i32,
     pub seed_parameter: i32,
     pub updated_at: chrono::NaiveDate,
-    pub durations: String,
-    pub frequencies: String,
+    pub durations_frequencies: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -151,8 +150,7 @@ pub struct IdfMetadataAvailability {
     pub quality_class: i32,
     pub seed_parameter: i32,
     pub updated_at: chrono::NaiveDate,
-    pub durations: Vec<u32>,
-    pub frequencies: Vec<i32>,
+    pub durations_frequencies: Vec<(u32, i32)>,
 }
 
 #[cfg(feature = "integration_tests")]
@@ -166,8 +164,7 @@ impl IdfMetadataAvailability {
         quality_class: i32,
         seed_parameter: i32,
         updated_at: chrono::NaiveDate,
-        durations: Vec<u32>,
-        frequencies: Vec<i32>,
+        durations_frequencies: Vec<(u32, i32)>,
     ) -> Self {
         Self {
             station_id,
@@ -177,8 +174,7 @@ impl IdfMetadataAvailability {
             quality_class,
             seed_parameter,
             updated_at,
-            durations,
-            frequencies,
+            durations_frequencies,
         }
     }
 }
@@ -220,8 +216,7 @@ pub fn create_idf_csv_content(
 
     for (station, station_data) in data {
         // write the metatada to metadata file
-        let mut durations: Vec<u32> = vec![];
-        let mut frequencies: Vec<i32> = vec![];
+        let mut durations_frequencies: Vec<(u32, i32)> = vec![];
         let metadata_clone = station_data.0.clone();
 
         let filename = format!("{station}.csv");
@@ -234,11 +229,8 @@ pub fn create_idf_csv_content(
         wtr.serialize(station_data.0)?;
         // write to data file
         for value in station_data.1 {
-            if !durations.contains(&value.duration) {
-                durations.push(value.duration);
-            }
-            if !frequencies.contains(&value.frequency) {
-                frequencies.push(value.frequency);
+            if !durations_frequencies.contains(&(value.duration, value.frequency)) {
+                durations_frequencies.push((value.duration, value.frequency));
             }
             wtr.serialize(value)?;
         }
@@ -246,12 +238,12 @@ pub fn create_idf_csv_content(
             wtr.into_inner()
                 .map_err(|e| Error::CsvWriterError(e.to_string()))?,
         )?;
-        let durations_string: Vec<String> =
-            durations.into_iter().map(|num| num.to_string()).collect();
-        let frequencies_string: Vec<String> =
-            frequencies.into_iter().map(|num| num.to_string()).collect();
-        let formated_durations_string = format!("[{}]", durations_string.join(","));
-        let formated_frequencies_string = format!("[{}]", frequencies_string.join(","));
+        let durations_frequencies_string: Vec<String> = durations_frequencies
+            .iter()
+            .map(|(duration, frequency)| format!("{}|{}", duration, frequency))
+            .collect();
+        let formated_durations_frequencies_string =
+            format!("[{}]", durations_frequencies_string.join(","));
         // add the durations and frequency metadata vectors
         let output_metadata: IdfMetadataOutput = IdfMetadataOutput {
             station_id: metadata_clone.station_id,
@@ -261,8 +253,7 @@ pub fn create_idf_csv_content(
             quality_class: metadata_clone.quality_class,
             seed_parameter: metadata_clone.seed_parameter,
             updated_at: metadata_clone.updated_at,
-            durations: formated_durations_string,
-            frequencies: formated_frequencies_string,
+            durations_frequencies: formated_durations_frequencies_string,
         };
         wtr_metadata.serialize(output_metadata)?;
         list_of_name_content.push((filename, data));


### PR DESCRIPTION
- [x] Return 404 when idf data not found (idf_handler), not 500
- [x]    Seems that its impossible to actually put a column that is an array into csv (with the rust csv writer), also nested structs aren't supported:  CsvError(Error(Serialize("serializing maps is not supported, if you have a use case, please file an issue at https://github.com/BurntSushi/rust-csv"))). So supporting creating these arrays for duration and frequencies is a bit of a hack, keeping it in the metadata file as a string, then parsing it back out. 
 {
      "stationId": 18165,
      "numberOfSeasons": 11,
      "fromTime": "2013-02-23",
      "toTime": "2024-12-31",
      "qualityClass": 3,
      "seedParameter": 1,
      "updatedAt": "2025-01-01",
      "durations": [10, 20, 30, 100, ...],
      "frequencies": [2, 5, 10, 20, 50, ...],
    },
    ...
instead of just
    {
      "stationId": 18165,
      "numberOfSeasons": 11,
      "fromTime": "2013-02-23",
      "toTime": "2024-12-31",
      "qualityClass": 3,
      "seedParameter": 1,
      "updatedAt": "2025-01-01"
    },