### PR TITLE
Documented and corrected humidity parameter calculations

### DIFF
--- a/egress/src/products/calculations.rs
+++ b/egress/src/products/calculations.rs
@@ -56,7 +56,7 @@ pub struct CalculationsDatum {
 }
 
 fn calculate_saturation_vapor_pressure(air_temperature: f64) -> f64 {
-    // ref.: The Relationship between Relative Humidity and the Dewpoint Temperature in Moist Air: 
+    // ref.: The Relationship between Relative Humidity and the Dewpoint Temperature in Moist Air:
     // A Simple Conversion and Applications (2005) - https://doi.org/10.1175/BAMS-86-2-225
     // Equation (6) : e_s = c * exp( (a * ta) / (b + ta) )
     // e_s = saturation_vapor_pressure [hPa]
@@ -68,8 +68,8 @@ fn calculate_saturation_vapor_pressure(air_temperature: f64) -> f64 {
     // - At higher temperatures, water molecules have more kinetic energy, leading to a rapid increase in vapor pressure.
     // - At lower temperatures (especially below freezing), the relationship changes due to differences in the behavior of ice versus liquid water.
     // Approxmations: Tetens or Aguste-Roche-Magnus equation... the form is the same, but coefficients differ based on temperature range.
-    // 
-    // [IMPORTANT] Here we use the following coefficients: 
+    //
+    // [IMPORTANT] Here we use the following coefficients:
     // for ta >  0, a = 17.08085 [rate] or [deg.C / deg.C], b = 234.175 [deg.C], and c = 6.10780 [hPa]. DEW POINT
     // for ta <= 0, a = 17.84362 [rate] or [deg.C / deg.C], b = 245.425 [deg.C], and c = 6.10780 [hPa]. FROST POINT
 
@@ -77,40 +77,50 @@ fn calculate_saturation_vapor_pressure(air_temperature: f64) -> f64 {
         return 6.10780 * (17.84362 * air_temperature / (245.425 + air_temperature)).exp();
     }
     6.10780 * (17.08085 * air_temperature / (234.175 + air_temperature)).exp()
-
 }
 
-pub fn calculate_water_vapor_partial_pressure(saturation_vapor_pressure: f64, relative_humidity: f64) -> f64 {
-    // ref.: The Relationship between Relative Humidity and the Dewpoint Temperature in Moist Air: 
+pub fn calculate_water_vapor_partial_pressure(
+    saturation_vapor_pressure: f64,
+    relative_humidity: f64,
+) -> f64 {
+    // ref.: The Relationship between Relative Humidity and the Dewpoint Temperature in Moist Air:
     // A Simple Conversion and Applications (2005) - https://doi.org/10.1175/BAMS-86-2-225
-    // Equation (3) : RH = 100 * e / e_s  -or-  e = (RH * e_s) / 100 
-    // 'RH' Relative humidity is commonly defined as the ratio of 
-    // 'e' the actual water vapor pressure [hPa] to 
+    // Equation (3) : RH = 100 * e / e_s  -or-  e = (RH * e_s) / 100
+    // 'RH' Relative humidity is commonly defined as the ratio of
+    // 'e' the actual water vapor pressure [hPa] to
     // 'e_s' the 'saturation' vapor pressure [hPa]
     // 1 hPa = 1 mb = 100 Pascals are units commonly used in meteorology and atmospheric sciences.
 
     (relative_humidity * saturation_vapor_pressure) / 100.0
 }
 
-pub fn calculate_dew_point_temperature(water_vapor_partial_pressure: f64, air_temperature: f64) -> f64 {
-    // ref.: The Relationship between Relative Humidity and the Dewpoint Temperature in Moist Air: 
+pub fn calculate_dew_point_temperature(
+    water_vapor_partial_pressure: f64,
+    air_temperature: f64,
+) -> f64 {
+    // ref.: The Relationship between Relative Humidity and the Dewpoint Temperature in Moist Air:
     // A Simple Conversion and Applications (2005) - https://doi.org/10.1175/BAMS-86-2-225
-    // Equation (7) : td = ( b * ln( e / c ) ) / ( a - ln( e / c ) ) 
+    // Equation (7) : td = ( b * ln( e / c ) ) / ( a - ln( e / c ) )
     // td = dew_point_temperature [deg.C]
     // e = water_vapor_partial_pressure [hPa]
     //
     // ekstra info: Guide to Instruments and Methods of Observation (WMO-No. 8)
     // Chapter 4: Humidity - Annex 4.B: Formulae for the computation of measures of humidity
     //
-    // Should we set a condition that dew_point_temperature cannot be greater than air_temperature??? 
+    // Should we set a condition that dew_point_temperature cannot be greater than air_temperature???
 
     if air_temperature <= 0.0 {
-        return 245.425 * (water_vapor_partial_pressure / 6.10780).ln() / (17.84362 - (water_vapor_partial_pressure / 6.10780).ln());
+        return 245.425 * (water_vapor_partial_pressure / 6.10780).ln()
+            / (17.84362 - (water_vapor_partial_pressure / 6.10780).ln());
     }
-    234.175 * (water_vapor_partial_pressure / 6.10780).ln() / (17.08085 - (water_vapor_partial_pressure / 6.10780).ln())
+    234.175 * (water_vapor_partial_pressure / 6.10780).ln()
+        / (17.08085 - (water_vapor_partial_pressure / 6.10780).ln())
 }
 
-pub fn calculate_humidity_mixing_ratio(water_vapor_partial_pressure: f64, surface_air_pressure: f64) -> f64 {
+pub fn calculate_humidity_mixing_ratio(
+    water_vapor_partial_pressure: f64,
+    surface_air_pressure: f64,
+) -> f64 {
     // ref.: Guide to Instruments and Methods of Observation (WMO-No. 8) - Chapter 4: Humidity
     // Annex 4.A: Definitions and specifications of water vapor in the atmosphere
     // Equation (4.A.1) : r = m_v / m_a
@@ -124,8 +134,9 @@ pub fn calculate_humidity_mixing_ratio(water_vapor_partial_pressure: f64, surfac
     // epsilon: ratio of the molecular weight of water vapor to dry air, approximately 0.62198 [dimensionless] or [g/mol / g/mol].
     //
     // IMPORTANT!! Add a CONVERSION from [kg/kg] to [g/kg] by multiplying by 1000 to match units for 'r' in stinfosys i.e. [g/kg].
-    
-    1000.0 * 0.62198 * water_vapor_partial_pressure / (surface_air_pressure - water_vapor_partial_pressure)
+
+    1000.0 * 0.62198 * water_vapor_partial_pressure
+        / (surface_air_pressure - water_vapor_partial_pressure)
 }
 
 pub fn calculate_specific_humidity(humidity_mixing_ratio: f64) -> f64 {
@@ -154,17 +165,21 @@ pub fn water_vapor_partial_pressure_in_air(
     relative_humidity: f64,
 ) -> Result<f64, Error> {
     let saturation_vapor_pressure = calculate_saturation_vapor_pressure(air_temperature);
-    Ok(calculate_water_vapor_partial_pressure(saturation_vapor_pressure, relative_humidity))
+    Ok(calculate_water_vapor_partial_pressure(
+        saturation_vapor_pressure,
+        relative_humidity,
+    ))
 }
 
 // dew_point_temperature
-pub fn dew_point_temperature(
-    air_temperature: f64,
-    relative_humidity: f64,
-) -> Result<f64, Error> {
+pub fn dew_point_temperature(air_temperature: f64, relative_humidity: f64) -> Result<f64, Error> {
     let saturation_vapor_pressure = calculate_saturation_vapor_pressure(air_temperature);
-    let water_vapor_partial_pressure = calculate_water_vapor_partial_pressure(saturation_vapor_pressure, relative_humidity);
-    Ok(calculate_dew_point_temperature(water_vapor_partial_pressure, air_temperature))
+    let water_vapor_partial_pressure =
+        calculate_water_vapor_partial_pressure(saturation_vapor_pressure, relative_humidity);
+    Ok(calculate_dew_point_temperature(
+        water_vapor_partial_pressure,
+        air_temperature,
+    ))
 }
 
 // over_time(humidity_mixing_ratio P1D)
@@ -174,8 +189,12 @@ pub fn humidity_mixing_ratio(
     surface_air_pressure: f64,
 ) -> Result<f64, Error> {
     let saturation_vapor_pressure = calculate_saturation_vapor_pressure(air_temperature);
-    let water_vapor_partial_pressure = calculate_water_vapor_partial_pressure(saturation_vapor_pressure, relative_humidity);
-    Ok(calculate_humidity_mixing_ratio(water_vapor_partial_pressure, surface_air_pressure))
+    let water_vapor_partial_pressure =
+        calculate_water_vapor_partial_pressure(saturation_vapor_pressure, relative_humidity);
+    Ok(calculate_humidity_mixing_ratio(
+        water_vapor_partial_pressure,
+        surface_air_pressure,
+    ))
 }
 
 // specific_humidity
@@ -185,8 +204,10 @@ pub fn specific_humidity(
     surface_air_pressure: f64,
 ) -> Result<f64, Error> {
     let saturation_vapor_pressure = calculate_saturation_vapor_pressure(air_temperature);
-    let water_vapor_partial_pressure = calculate_water_vapor_partial_pressure(saturation_vapor_pressure, relative_humidity);
-    let humidity_mixing_ratio = calculate_humidity_mixing_ratio(water_vapor_partial_pressure, surface_air_pressure);
+    let water_vapor_partial_pressure =
+        calculate_water_vapor_partial_pressure(saturation_vapor_pressure, relative_humidity);
+    let humidity_mixing_ratio =
+        calculate_humidity_mixing_ratio(water_vapor_partial_pressure, surface_air_pressure);
     Ok(calculate_specific_humidity(humidity_mixing_ratio))
 }
 


### PR DESCRIPTION
I verified the equations based on published equations from:
- The WMO Guide to Instruments and Methods of Observation (WMO-No. 8) - Chapter 4: Humidity, Annex 4.A: Definitions and specifications of water vapor in the atmosphere and Annex 4.B,
- The Relationship between Relative Humidity and the Dewpoint Temperature in Moist Air: A Simple Conversion and Applications (2005) - https://doi.org/10.1175/BAMS-86-2-225
- Technical specifications for Weather Stations operated by the Norwegian Meteorological Institute and external partners (i.e. SVV). - 

The value and units of the parameters of the equations were corrected to match the references and the units used at Met.